### PR TITLE
Fix panic error when a flow contains a flow conductor node which isn't using a subflow capability

### DIFF
--- a/.changelog/285.txt
+++ b/.changelog/285.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/davinci_flow`: Fixed panic error when the flow JSON contains a flow conductor node which isn't using a subflow capability.
+```

--- a/internal/service/davinci/resource_flow.go
+++ b/internal/service/davinci/resource_flow.go
@@ -1127,6 +1127,62 @@ func flowVariablesToTF(apiObject []davinci.FlowVariable) (types.Set, diag.Diagno
 	return returnVar, diags
 }
 
+type flowConnectionNodeModel struct {
+	connectionID        string
+	connectorID         string
+	id                  string
+	name                string
+	nodeType            string
+	subFlowIDValueLabel string
+	subFlowIDValueValue string
+}
+
+func parseFlowNodeProperties(node davinci.Node) flowConnectionNodeModel {
+
+	returnVar := flowConnectionNodeModel{}
+
+	if nd := node.Data; nd != nil {
+
+		if v := nd.ConnectionID; v != nil {
+			returnVar.connectionID = *v
+		}
+
+		if v := nd.ConnectorID; v != nil {
+			returnVar.connectorID = *v
+		}
+
+		if v := nd.ID; v != nil {
+			returnVar.id = *v
+		}
+
+		if v := nd.Name; v != nil {
+			returnVar.name = *v
+		}
+
+		if v := nd.NodeType; v != nil {
+			returnVar.nodeType = *v
+		}
+
+		if ndp := nd.Properties; ndp != nil {
+			if ndps := ndp.SubFlowID; ndps != nil {
+				if ndpsv := ndps.Value; ndpsv != nil {
+
+					if v := ndpsv.Label; v != nil {
+						returnVar.subFlowIDValueLabel = *v
+					}
+
+					if v := ndpsv.Value; v != nil {
+						returnVar.subFlowIDValueValue = *v
+					}
+
+				}
+			}
+		}
+	}
+
+	return returnVar
+}
+
 // Validate if there are connections in the flow that should have a connection mapping, and flow connector instances that should have a subflow mapping
 func validateConnectionSubflowLinkMappings(ctx context.Context, flowJSON davinciexporttype.ParsedValue, connectionLinks basetypes.SetValue, subFlowLinks basetypes.SetValue, allowUnknownValues bool) (diags diag.Diagnostics) {
 
@@ -1152,7 +1208,9 @@ func validateConnectionSubflowLinkMappings(ctx context.Context, flowJSON davinci
 
 			for _, node := range flowConfigObject.GraphData.Elements.Nodes {
 
-				if node.Data != nil && (node.Data.NodeType != nil && *node.Data.NodeType == "CONNECTION") || (node.Data.ConnectorID != nil && *node.Data.ConnectorID != "") {
+				nodeObject := parseFlowNodeProperties(node)
+
+				if nodeObject.nodeType == "CONNECTION" || nodeObject.connectorID != "" {
 
 					connectionLinkFound := false
 
@@ -1169,11 +1227,11 @@ func validateConnectionSubflowLinkMappings(ctx context.Context, flowJSON davinci
 							return diags
 						}
 
-						if node.Data.ConnectionID != nil && !connectionLinkPlan.ReplaceImportConnectionId.IsNull() && connectionLinkPlan.ReplaceImportConnectionId.ValueString() == *node.Data.ConnectionID {
+						if !connectionLinkPlan.ReplaceImportConnectionId.IsNull() && connectionLinkPlan.ReplaceImportConnectionId.ValueString() == nodeObject.connectionID {
 							connectionLinkFound = true
 						}
 
-						if node.Data.Name != nil && connectionLinkPlan.Name.ValueString() == *node.Data.Name {
+						if connectionLinkPlan.Name.ValueString() == nodeObject.name {
 							connectionLinkFound = true
 						}
 
@@ -1190,12 +1248,12 @@ func validateConnectionSubflowLinkMappings(ctx context.Context, flowJSON davinci
 							fmt.Sprintf("The flow JSON to import (provided in the `flow_json` parameter) contains a node connection that does not have a `connection_link` mapping.  This behaviour is deprecated - going forward all connections in a flow must have a `connection_link` block parameter defined.\n\n"+
 								"Consider using the `davinci_connection` resource (to create a Terraform managed connection) with the `davinci_flow.connection_link` parameter (to map the Terraform managed connection with the connection in the flow).\n"+
 								"For more information and guidance on how to correctly configure flow connections, visit https://github.com/pingidentity/terraform-provider-davinci/issues/272\n\n"+
-								"Connection ID: %v\nConnector ID: %v\nConnection Name: %v\nNode Type: %v\nNode ID: %v", *node.Data.ConnectionID, *node.Data.ConnectorID, *node.Data.Name, *node.Data.NodeType, *node.Data.ID),
+								"Connection ID: %s\nConnector ID: %s\nConnection Name: %s\nNode Type: %s\nNode ID: %s", nodeObject.connectionID, nodeObject.connectorID, nodeObject.name, nodeObject.nodeType, nodeObject.id),
 						)
 					}
 
 					// Validate the subflow link mapping if necessary
-					if node.Data.ConnectorID != nil && *node.Data.ConnectorID == "flowConnector" {
+					if nodeObject.connectorID == "flowConnector" {
 						subflowLinkFound := false
 
 						for _, subflowLinkPlan := range subflowLinksPlan {
@@ -1210,11 +1268,11 @@ func validateConnectionSubflowLinkMappings(ctx context.Context, flowJSON davinci
 								return diags
 							}
 
-							if node.Data.Properties != nil && node.Data.Properties.SubFlowID != nil && node.Data.Properties.SubFlowID.Value != nil && node.Data.Properties.SubFlowID.Value.Value != nil && !subflowLinkPlan.ReplaceImportSubflowId.IsNull() && subflowLinkPlan.ReplaceImportSubflowId.ValueString() == *node.Data.Properties.SubFlowID.Value.Value {
+							if !subflowLinkPlan.ReplaceImportSubflowId.IsNull() && subflowLinkPlan.ReplaceImportSubflowId.ValueString() == nodeObject.subFlowIDValueValue {
 								subflowLinkFound = true
 							}
 
-							if node.Data.Properties != nil && node.Data.Properties.SubFlowID != nil && node.Data.Properties.SubFlowID.Value != nil && node.Data.Properties.SubFlowID.Value.Label != nil && subflowLinkPlan.Name.ValueString() == *node.Data.Properties.SubFlowID.Value.Label {
+							if subflowLinkPlan.Name.ValueString() == nodeObject.subFlowIDValueLabel {
 								subflowLinkFound = true
 							}
 
@@ -1230,7 +1288,7 @@ func validateConnectionSubflowLinkMappings(ctx context.Context, flowJSON davinci
 								fmt.Sprintf("The flow JSON to import (provided in the `flow_json` parameter) contains a subflow referenced in a flow connector that does not have a `subflow_link` mapping.  This behaviour is deprecated - going forward all subflows defined in a flow must have a `subflow_link` block parameter defined.\n\n"+
 									"Consider using the `davinci_flow` resource (to create the subflow) with the `davinci_flow.subflow_link` parameter (to map the Terraform managed subflow with the main flow).\n"+
 									"For more information and guidance on how to correctly configure subflow connections, visit https://github.com/pingidentity/terraform-provider-davinci/issues/273\n\n"+
-									"Connection ID: %v\nConnector ID: %v\nConnection Name: %v\nNode Type: %v\nNode ID: %v\nSubflow Name: %v\nSubflow ID: %v", *node.Data.ConnectionID, *node.Data.ConnectorID, *node.Data.Name, *node.Data.NodeType, *node.Data.ID, *node.Data.Properties.SubFlowID.Value.Label, *node.Data.Properties.SubFlowID.Value.Value),
+									"Connection ID: %s\nConnector ID: %s\nConnection Name: %s\nNode Type: %s\nNode ID: %s\nSubflow Name: %s\nSubflow ID: %s", nodeObject.connectionID, nodeObject.connectorID, nodeObject.name, nodeObject.nodeType, nodeObject.id, nodeObject.subFlowIDValueLabel, nodeObject.subFlowIDValueValue),
 							)
 						}
 					}
@@ -1283,7 +1341,9 @@ func modifyPlanForConnectionSubflowLinkMappings(ctx context.Context, flowConfigO
 		newNodes := make([]davinci.Node, 0)
 		for _, node := range flowConfigObject.GraphData.Elements.Nodes {
 
-			if !unknownFlowConfigPlan && ((node.Data.NodeType != nil && *node.Data.NodeType == "CONNECTION") || (node.Data.ConnectorID != nil && *node.Data.ConnectorID != "")) {
+			nodeObject := parseFlowNodeProperties(node)
+
+			if !unknownFlowConfigPlan && (nodeObject.nodeType == "CONNECTION" || nodeObject.connectorID != "") {
 
 				// Find the connection_link reference
 				for _, connectionLinkPlan := range connectionLinksPlan {
@@ -1302,7 +1362,7 @@ func modifyPlanForConnectionSubflowLinkMappings(ctx context.Context, flowConfigO
 						node.Data.ConnectionID = &connectionID
 						node.Data.Name = &connectionName
 
-					} else if node.Data != nil && node.Data.Name != nil && connectionLinkPlan.Name.ValueString() == *node.Data.Name {
+					} else if connectionLinkPlan.Name.ValueString() == nodeObject.name {
 						// If we're here, the replace import connection ID is known to be null, so we do name matching
 
 						// replace the ID in the flowConfigObject
@@ -1311,7 +1371,7 @@ func modifyPlanForConnectionSubflowLinkMappings(ctx context.Context, flowConfigO
 					}
 				}
 
-				if !unknownFlowConfigPlan && node.Data.ConnectorID != nil && *node.Data.ConnectorID == "flowConnector" {
+				if !unknownFlowConfigPlan && nodeObject.connectorID == "flowConnector" {
 
 					// Find the subflow_link reference
 					for _, subflowLinkPlan := range subflowLinksPlan {
@@ -1322,7 +1382,7 @@ func modifyPlanForConnectionSubflowLinkMappings(ctx context.Context, flowConfigO
 						}
 
 						// If the replace import connection ID is known and not null, we can replace the connection ID in the flowConfigObject
-						if node.Data.Properties != nil && node.Data.Properties.SubFlowID != nil && node.Data.Properties.SubFlowID.Value != nil && node.Data.Properties.SubFlowID.Value.Value != nil && !subflowLinkPlan.ReplaceImportSubflowId.IsNull() && subflowLinkPlan.ReplaceImportSubflowId.ValueString() == *node.Data.Properties.SubFlowID.Value.Value {
+						if !subflowLinkPlan.ReplaceImportSubflowId.IsNull() && subflowLinkPlan.ReplaceImportSubflowId.ValueString() == nodeObject.subFlowIDValueValue {
 
 							// replace the ID and label
 							subflowPlanValue := subflowLinkPlan.Id.ValueString()
@@ -1330,7 +1390,7 @@ func modifyPlanForConnectionSubflowLinkMappings(ctx context.Context, flowConfigO
 							node.Data.Properties.SubFlowID.Value.Value = &subflowPlanValue
 							node.Data.Properties.SubFlowID.Value.Label = &subflowPlanLabel
 
-						} else if node.Data.Properties != nil && node.Data.Properties.SubFlowID != nil && node.Data.Properties.SubFlowID.Value != nil && node.Data.Properties.SubFlowID.Value.Label != nil && subflowLinkPlan.Name.ValueString() == *node.Data.Properties.SubFlowID.Value.Label {
+						} else if subflowLinkPlan.Name.ValueString() == nodeObject.subFlowIDValueLabel {
 							// If we're here, the replace import connection ID is known to be null, so we do name matching
 
 							// replace the ID in the flowConfigObject

--- a/internal/service/davinci/resource_flow.go
+++ b/internal/service/davinci/resource_flow.go
@@ -1135,11 +1135,14 @@ type flowConnectionNodeModel struct {
 	nodeType            string
 	subFlowIDValueLabel string
 	subFlowIDValueValue string
+	hasSubflowRef       bool
 }
 
 func parseFlowNodeProperties(node davinci.Node) flowConnectionNodeModel {
 
-	returnVar := flowConnectionNodeModel{}
+	returnVar := flowConnectionNodeModel{
+		hasSubflowRef: false,
+	}
 
 	if nd := node.Data; nd != nil {
 
@@ -1166,6 +1169,8 @@ func parseFlowNodeProperties(node davinci.Node) flowConnectionNodeModel {
 		if ndp := nd.Properties; ndp != nil {
 			if ndps := ndp.SubFlowID; ndps != nil {
 				if ndpsv := ndps.Value; ndpsv != nil {
+
+					returnVar.hasSubflowRef = true
 
 					if v := ndpsv.Label; v != nil {
 						returnVar.subFlowIDValueLabel = *v
@@ -1253,7 +1258,7 @@ func validateConnectionSubflowLinkMappings(ctx context.Context, flowJSON davinci
 					}
 
 					// Validate the subflow link mapping if necessary
-					if nodeObject.connectorID == "flowConnector" {
+					if nodeObject.connectorID == "flowConnector" && nodeObject.hasSubflowRef {
 						subflowLinkFound := false
 
 						for _, subflowLinkPlan := range subflowLinksPlan {
@@ -1371,7 +1376,7 @@ func modifyPlanForConnectionSubflowLinkMappings(ctx context.Context, flowConfigO
 					}
 				}
 
-				if !unknownFlowConfigPlan && nodeObject.connectorID == "flowConnector" {
+				if !unknownFlowConfigPlan && nodeObject.connectorID == "flowConnector" && nodeObject.hasSubflowRef {
 
 					// Find the subflow_link reference
 					for _, subflowLinkPlan := range subflowLinksPlan {


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/davinci_flow`: Fixed panic error when the flow JSON contains a flow conductor node which isn't using a subflow capability.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccResourceFlow_ github.com/pingidentity/terraform-provider-davinci/internal/service/davinci
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccResourceFlow_RemovalDrift
=== PAUSE TestAccResourceFlow_RemovalDrift
=== RUN   TestAccResourceFlow_Basic_Clean
=== PAUSE TestAccResourceFlow_Basic_Clean
=== RUN   TestAccResourceFlow_Basic_WithBootstrap
=== PAUSE TestAccResourceFlow_Basic_WithBootstrap
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== RUN   TestAccResourceFlow_ComputeDifferences_ModifySettings
=== PAUSE TestAccResourceFlow_ComputeDifferences_ModifySettings
=== RUN   TestAccResourceFlow_ComputeDifferences_CompanyId
=== PAUSE TestAccResourceFlow_ComputeDifferences_CompanyId
=== RUN   TestAccResourceFlow_ComputeDifferences_Version
=== PAUSE TestAccResourceFlow_ComputeDifferences_Version
=== RUN   TestAccResourceFlow_ComputeDifferences_Description
=== PAUSE TestAccResourceFlow_ComputeDifferences_Description
=== RUN   TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== PAUSE TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== RUN   TestAccResourceFlow_ComputeDifferences_NewNode
=== PAUSE TestAccResourceFlow_ComputeDifferences_NewNode
=== RUN   TestAccResourceFlow_BrokenFlow
=== PAUSE TestAccResourceFlow_BrokenFlow
=== RUN   TestAccResourceFlow_BadParameters
=== PAUSE TestAccResourceFlow_BadParameters
=== CONT  TestAccResourceFlow_RemovalDrift
=== CONT  TestAccResourceFlow_ComputeDifferences_CompanyId
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== CONT  TestAccResourceFlow_Basic_WithBootstrap
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== CONT  TestAccResourceFlow_BadParameters
=== CONT  TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== CONT  TestAccResourceFlow_BrokenFlow
=== CONT  TestAccResourceFlow_ComputeDifferences_ModifySettings
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== CONT  TestAccResourceFlow_ComputeDifferences_NewNode
=== CONT  TestAccResourceFlow_Basic_Clean
=== CONT  TestAccResourceFlow_ComputeDifferences_Description
=== CONT  TestAccResourceFlow_ComputeDifferences_Version
=== NAME  TestAccResourceFlow_Basic_WithBootstrap
    resource_flow_test.go:179: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_Basic_WithBootstrap (0.01s)
=== NAME  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
    resource_flow_test.go:322: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap (0.01s)
--- PASS: TestAccResourceFlow_BrokenFlow (206.94s)
=== NAME  TestAccResourceFlow_RemovalDrift
    resource_flow_test.go:39: Skipping step 3/4 due to SkipFunc
    resource_flow_test.go:39: Skipping step 4/4 due to SkipFunc
--- PASS: TestAccResourceFlow_RemovalDrift (267.99s)
--- PASS: TestAccResourceFlow_BadParameters (279.64s)
--- PASS: TestAccResourceFlow_ComputeDifferences_NewNode (323.67s)
--- PASS: TestAccResourceFlow_ComputeDifferences_Version (333.55s)
--- PASS: TestAccResourceFlow_ComputeDifferences_ModifySettings (334.21s)
--- PASS: TestAccResourceFlow_ComputeDifferences_AdditionalProperties (334.76s)
--- PASS: TestAccResourceFlow_ComputeDifferences_CompanyId (336.38s)
--- PASS: TestAccResourceFlow_ComputeDifferences_Description (337.12s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean (516.98s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean (525.43s)
--- PASS: TestAccResourceFlow_Basic_Clean (533.36s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap (991.15s)
PASS
ok      github.com/pingidentity/terraform-provider-davinci/internal/service/davinci     991.808s
```

</details>