### PR TITLE
`resource/davinci_flow`: Skip forward plan modification when the json import is unknown

### DIFF
--- a/.changelog/306.txt
+++ b/.changelog/306.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/davinci_flow`: Fixed "Error parsing `flow_json`" error when the `flow_json` string is unknown during plan.
+```

--- a/internal/service/davinci/resource_flow_test.go
+++ b/internal/service/davinci/resource_flow_test.go
@@ -792,6 +792,39 @@ func testAccResourceFlow_ComputeDifferences(t *testing.T, cd computeDifferencesT
 	})
 }
 
+func TestAccResourceFlow_UnknownFlowString(t *testing.T) {
+
+	resourceBase := "davinci_flow"
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("%s.%s", resourceBase, resourceName)
+
+	name := resourceName
+
+	stepHcl, err := testAccResourceFlow_UnknownFlow_HCL(resourceName, name)
+	if err != nil {
+		t.Fatalf("Failed to get HCL: %v", err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNewEnvironment(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		CheckDestroy:             davinci.Flow_CheckDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: stepHcl,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1DVResourceIDRegexpFullString),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceFlow_BrokenFlow(t *testing.T) {
 
 	resourceName := acctest.ResourceNameGen()
@@ -1383,6 +1416,125 @@ EOT
     replace_import_connection_id = "53ab83a4a4ab919d9f2cb02d9e111ac8"
   }
 }`, acctest.PingoneEnvironmentSsoHcl(resourceName, false), resourceName, flowJson), nil
+}
+
+func testAccResourceFlow_UnknownFlow_HCL(resourceName, name string) (hcl string, err error) {
+
+	mainFlowJson, err := acctest.ReadFlowJsonFile("flows/full-minimal.json")
+	if err != nil {
+		return "", err
+	}
+
+	commonHcl, err := testAccResourceFlow_Common_WithMappingIDs_HCL(resourceName, name)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "davinci_flow" "%[3]s" {
+  environment_id = pingone_environment.%[3]s.id
+
+  flow_json = <<EOT
+{
+  "companyId": "2c6123ae-108f-4d11-bcc2-6c8f4dfa9fdb",
+  "authTokenExpireIds": [],
+  "connectorIds": [
+    "errorConnector"
+  ],
+  "createdDate": 1707837216607,
+  "currentVersion": 4,
+  "customerId": "db5f4450b2bd8a56ce076dec0c358a9a",
+  "deployedDate": 1707837221226,
+  "description": "Imported on Wed Jan 31 2024 13:29:13 GMT+0000 (Coordinated Universal Time)",
+  "flowStatus": "enabled",
+  "isOutputSchemaSaved": false,
+  "name": "simple",
+  "publishedVersion": 4,
+  "settings": {
+    "csp": "worker-src 'self' blob:; script-src 'self' https://cdn.jsdelivr.net https://code.jquery.com https://devsdk.singularkey.com http://cdnjs.cloudflare.com 'unsafe-inline' 'unsafe-eval';",
+    "intermediateLoadingScreenCSS": "",
+    "intermediateLoadingScreenHTML": "",
+    "flowHttpTimeoutInSeconds": 300,
+    "logLevel": 1,
+    "useCustomCSS": true
+  },
+  "timeouts": "null",
+  "updatedDate": 1707837221226,
+  "flowId": "8f93840f61b58b043a0a38439a1c6640",
+  "versionId": 4,
+  "graphData": {
+    "elements": {
+      "nodes": [
+        {
+          "data": {
+            "id": "2pzouq7el7",
+            "nodeType": "CONNECTION",
+            "connectionId": "53ab83a4a4ab919d9f2cb02d9e111ac8",
+            "connectorId": "errorConnector",
+            "name": "Error Message",
+            "label": "Error Message",
+            "status": "configured",
+            "capabilityName": "customErrorMessage",
+            "type": "action",
+            "properties": {
+              "errorMessage": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"This is an error - ${davinci_connection.%[3]s-error.id}\"\n      }\n    ]\n  }\n]"
+              },
+              "errorDescription": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"This is an error, really\"\n      }\n    ]\n  }\n]"
+              }
+            }
+          },
+          "position": {
+            "x": 400,
+            "y": 400
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        }
+      ]
+    },
+    "data": {},
+    "zoomingEnabled": true,
+    "userZoomingEnabled": true,
+    "zoom": 1,
+    "minZoom": 1e-50,
+    "maxZoom": 1e+50,
+    "panningEnabled": true,
+    "userPanningEnabled": true,
+    "pan": {
+      "x": 0,
+      "y": 0
+    },
+    "boxSelectionEnabled": true,
+    "renderer": {
+      "name": "null"
+    }
+  },
+  "flowColor": "#FFC8C1",
+  "savedDate": 1707837216592,
+  "variables": [],
+  "connections": []
+}
+EOT
+
+  // Error connector
+  connection_link {
+    id                           = davinci_connection.%[3]s-error.id
+    name                         = davinci_connection.%[3]s-error.name
+    replace_import_connection_id = "53ab83a4a4ab919d9f2cb02d9e111ac8"
+  }
+}`, acctest.PingoneEnvironmentSsoHcl(resourceName, false), commonHcl, resourceName, mainFlowJson), nil
 }
 
 // // tests for changes other than graph data.


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/davinci_flow`: Skip forward plan modification when the json import is unknown

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccResourceFlow_ github.com/pingidentity/terraform-provider-davinci/internal/service/davinci
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccResourceFlow_RemovalDrift
=== PAUSE TestAccResourceFlow_RemovalDrift
=== RUN   TestAccResourceFlow_Basic_Clean
=== PAUSE TestAccResourceFlow_Basic_Clean
=== RUN   TestAccResourceFlow_Basic_WithBootstrap
=== PAUSE TestAccResourceFlow_Basic_WithBootstrap
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== RUN   TestAccResourceFlow_ComputeDifferences_ModifySettings
=== PAUSE TestAccResourceFlow_ComputeDifferences_ModifySettings
=== RUN   TestAccResourceFlow_ComputeDifferences_CompanyId
=== PAUSE TestAccResourceFlow_ComputeDifferences_CompanyId
=== RUN   TestAccResourceFlow_ComputeDifferences_Version
=== PAUSE TestAccResourceFlow_ComputeDifferences_Version
=== RUN   TestAccResourceFlow_ComputeDifferences_Description
=== PAUSE TestAccResourceFlow_ComputeDifferences_Description
=== RUN   TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== PAUSE TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== RUN   TestAccResourceFlow_ComputeDifferences_NewNode
=== PAUSE TestAccResourceFlow_ComputeDifferences_NewNode
=== RUN   TestAccResourceFlow_UnknownFlowString
=== PAUSE TestAccResourceFlow_UnknownFlowString
=== RUN   TestAccResourceFlow_BrokenFlow
=== PAUSE TestAccResourceFlow_BrokenFlow
=== RUN   TestAccResourceFlow_BadParameters
=== PAUSE TestAccResourceFlow_BadParameters
=== CONT  TestAccResourceFlow_RemovalDrift
=== CONT  TestAccResourceFlow_ComputeDifferences_CompanyId
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== CONT  TestAccResourceFlow_Basic_WithBootstrap
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== CONT  TestAccResourceFlow_ComputeDifferences_NewNode
=== CONT  TestAccResourceFlow_Basic_Clean
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== CONT  TestAccResourceFlow_ComputeDifferences_Description
=== CONT  TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== CONT  TestAccResourceFlow_ComputeDifferences_Version
=== CONT  TestAccResourceFlow_ComputeDifferences_ModifySettings
=== CONT  TestAccResourceFlow_BrokenFlow
=== CONT  TestAccResourceFlow_BadParameters
=== CONT  TestAccResourceFlow_UnknownFlowString
=== NAME  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
    resource_flow_test.go:322: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap (0.01s)
=== NAME  TestAccResourceFlow_Basic_WithBootstrap
    resource_flow_test.go:179: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_Basic_WithBootstrap (0.01s)
--- PASS: TestAccResourceFlow_BrokenFlow (174.10s)
=== NAME  TestAccResourceFlow_RemovalDrift
    resource_flow_test.go:39: Skipping step 3/4 due to SkipFunc
    resource_flow_test.go:39: Skipping step 4/4 due to SkipFunc
--- PASS: TestAccResourceFlow_UnknownFlowString (229.94s)
--- PASS: TestAccResourceFlow_RemovalDrift (238.38s)
--- PASS: TestAccResourceFlow_BadParameters (248.24s)
--- PASS: TestAccResourceFlow_ComputeDifferences_NewNode (269.84s)
--- PASS: TestAccResourceFlow_ComputeDifferences_Description (276.70s)
--- PASS: TestAccResourceFlow_ComputeDifferences_CompanyId (276.79s)
--- PASS: TestAccResourceFlow_ComputeDifferences_ModifySettings (291.30s)
--- PASS: TestAccResourceFlow_ComputeDifferences_Version (291.81s)
--- PASS: TestAccResourceFlow_ComputeDifferences_AdditionalProperties (292.05s)
--- PASS: TestAccResourceFlow_Basic_Clean (519.48s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean (521.44s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean (528.89s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap (882.62s)
PASS
ok      github.com/pingidentity/terraform-provider-davinci/internal/service/davinci     883.315s
```

</details>