### PR TITLE
`resource/davinci_flow`: include a `flow_variables` plan derived from the flow import JSON

### DIFF
--- a/.changelog/308.txt
+++ b/.changelog/308.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/davinci_flow`: `flow_variables` now includes a plan derived from the flow import JSON.
+```


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/davinci_flow`: `flow_variables` now includes a plan derived from the flow import JSON.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccResourceFlow_ github.com/pingidentity/terraform-provider-davinci/internal/service/davinci
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccResourceFlow_RemovalDrift
=== PAUSE TestAccResourceFlow_RemovalDrift
=== RUN   TestAccResourceFlow_Basic_Clean
=== PAUSE TestAccResourceFlow_Basic_Clean
=== RUN   TestAccResourceFlow_Basic_WithBootstrap
=== PAUSE TestAccResourceFlow_Basic_WithBootstrap
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== RUN   TestAccResourceFlow_ComputeDifferences_ModifySettings
=== PAUSE TestAccResourceFlow_ComputeDifferences_ModifySettings
=== RUN   TestAccResourceFlow_ComputeDifferences_CompanyId
=== PAUSE TestAccResourceFlow_ComputeDifferences_CompanyId
=== RUN   TestAccResourceFlow_ComputeDifferences_Version
=== PAUSE TestAccResourceFlow_ComputeDifferences_Version
=== RUN   TestAccResourceFlow_ComputeDifferences_Description
=== PAUSE TestAccResourceFlow_ComputeDifferences_Description
=== RUN   TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== PAUSE TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== RUN   TestAccResourceFlow_ComputeDifferences_NewNode
=== PAUSE TestAccResourceFlow_ComputeDifferences_NewNode
=== RUN   TestAccResourceFlow_UnknownFlowString
=== PAUSE TestAccResourceFlow_UnknownFlowString
=== RUN   TestAccResourceFlow_BrokenFlow
=== PAUSE TestAccResourceFlow_BrokenFlow
=== RUN   TestAccResourceFlow_BadParameters
=== PAUSE TestAccResourceFlow_BadParameters
=== CONT  TestAccResourceFlow_RemovalDrift
=== CONT  TestAccResourceFlow_ComputeDifferences_CompanyId
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== CONT  TestAccResourceFlow_BrokenFlow
=== CONT  TestAccResourceFlow_UnknownFlowString
=== CONT  TestAccResourceFlow_ComputeDifferences_Description
=== CONT  TestAccResourceFlow_Basic_Clean
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== CONT  TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== CONT  TestAccResourceFlow_ComputeDifferences_ModifySettings
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== CONT  TestAccResourceFlow_ComputeDifferences_Version
=== CONT  TestAccResourceFlow_BadParameters
=== CONT  TestAccResourceFlow_Basic_WithBootstrap
=== CONT  TestAccResourceFlow_ComputeDifferences_NewNode
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== NAME  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
    resource_flow_test.go:322: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap (0.01s)
=== NAME  TestAccResourceFlow_Basic_WithBootstrap
    resource_flow_test.go:179: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_Basic_WithBootstrap (0.01s)
--- PASS: TestAccResourceFlow_BrokenFlow (189.78s)
--- PASS: TestAccResourceFlow_UnknownFlowString (242.51s)
=== NAME  TestAccResourceFlow_RemovalDrift
    resource_flow_test.go:39: Skipping step 3/4 due to SkipFunc
    resource_flow_test.go:39: Skipping step 4/4 due to SkipFunc
--- PASS: TestAccResourceFlow_RemovalDrift (256.67s)
--- PASS: TestAccResourceFlow_BadParameters (269.96s)
--- PASS: TestAccResourceFlow_ComputeDifferences_Version (281.30s)
--- PASS: TestAccResourceFlow_ComputeDifferences_AdditionalProperties (285.14s)
--- PASS: TestAccResourceFlow_ComputeDifferences_Description (286.52s)
--- PASS: TestAccResourceFlow_ComputeDifferences_NewNode (292.16s)
--- PASS: TestAccResourceFlow_ComputeDifferences_ModifySettings (296.71s)
--- PASS: TestAccResourceFlow_ComputeDifferences_CompanyId (296.79s)
--- PASS: TestAccResourceFlow_Basic_Clean (524.23s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean (529.40s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean (533.02s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap (899.95s)
PASS
ok      github.com/pingidentity/terraform-provider-davinci/internal/service/davinci     900.676s
```

</details>