### PR TITLE
Add company variable `type` = `secret` tests

### DIFF
--- a/.changelog/358.txt
+++ b/.changelog/358.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/davinci_variable`: Fix "Provider produced inconsistent result after apply" when defining a variable of `type` = `secret`.
+```

--- a/docs/resources/variable.md
+++ b/docs/resources/variable.md
@@ -149,12 +149,12 @@ resource "davinci_variable" "my_awesome_usercontext_variable" {
 ### Optional
 
 - `description` (String) A string that specifies the description of the variable.
-- `empty_value` (Boolean) A boolean that specifies whether the variable's `value` must be kept as an empty string.  Conflicts with `value`, `empty_value`.
+- `empty_value` (Boolean) A boolean that specifies whether the variable's `value` must be kept as an empty string.  Conflicts with `value`.
 - `flow_id` (String) A string that specifies the ID of the flow to which the variable is assigned.  This field is required when the `context` field is set to `flow`.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
 - `max` (Number) An integer that specifies the maximum value of the variable, if the `type` parameter is set as `number`.  Defaults to `2000`.
 - `min` (Number) An integer that specifies the minimum value of the variable, if the `type` parameter is set as `number`.  Defaults to `0`.
 - `mutable` (Boolean) A boolean that specifies whether the variable is mutable.  If `true`, the variable can be modified by the flow. If `false`, the variable is read-only and cannot be modified by the flow.  Defaults to `true`.
-- `value` (String, Sensitive) A string that specifies the default value of the variable, the type will be inferred from the value specified in the `type` parameter.  If left blank or omitted, the resource will not track the variable's value in state.  If the variable value should be tracked in state as an empty string, use the `empty_value` parameter.  Conflicts with `value`, `empty_value`.
+- `value` (String, Sensitive) A string that specifies the default value of the variable, the type will be inferred from the value specified in the `type` parameter.  If left blank or omitted, the resource will not track the variable's value in state.  If the variable value should be tracked in state as an empty string, use the `empty_value` parameter.  Note that if the `type` is `secret`, the provider will not be able to remediate the value's configuration drift in the DaVinci service.  Conflicts with `empty_value`.
 
 ### Read-Only
 

--- a/internal/service/davinci/resource_variable.go
+++ b/internal/service/davinci/resource_variable.go
@@ -103,8 +103,8 @@ func (r *VariableResource) Schema(ctx context.Context, req resource.SchemaReques
 	).DefaultValue(true)
 
 	valueDescription := framework.SchemaAttributeDescriptionFromMarkdown(
-		"A string that specifies the default value of the variable, the type will be inferred from the value specified in the `type` parameter.  If left blank or omitted, the resource will not track the variable's value in state.  If the variable value should be tracked in state as an empty string, use the `empty_value` parameter.",
-	).ConflictsWith([]string{"value", "empty_value"})
+		"A string that specifies the default value of the variable, the type will be inferred from the value specified in the `type` parameter.  If left blank or omitted, the resource will not track the variable's value in state.  If the variable value should be tracked in state as an empty string, use the `empty_value` parameter.  Note that if the `type` is `secret`, the provider will not be able to remediate the value's configuration drift in the DaVinci service.",
+	).ConflictsWith([]string{"empty_value"})
 
 	valueServiceDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that specifies the value of the variable in the service, the type will be inferred from the value specified in the `type` parameter.",
@@ -112,7 +112,7 @@ func (r *VariableResource) Schema(ctx context.Context, req resource.SchemaReques
 
 	EmptyValueDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A boolean that specifies whether the variable's `value` must be kept as an empty string.",
-	).ConflictsWith([]string{"value", "empty_value"})
+	).ConflictsWith([]string{"value"})
 
 	minDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"An integer that specifies the minimum value of the variable, if the `type` parameter is set as `number`.",

--- a/internal/service/davinci/resource_variable.go
+++ b/internal/service/davinci/resource_variable.go
@@ -728,7 +728,9 @@ func (p *VariableResourceModel) toState(apiObject map[string]davinci.Variable) d
 	// }
 
 	if v := variableObject.Value; v != nil && *v != "" {
-		p.ValueService = framework.StringToTF(*v)
+		value := *v
+		value = regexp.MustCompile(`^\*+$`).ReplaceAllString(value, p.Value.ValueString())
+		p.ValueService = framework.StringToTF(value)
 	} else {
 		p.ValueService = types.StringNull()
 	}

--- a/internal/service/davinci/resource_variable_test.go
+++ b/internal/service/davinci/resource_variable_test.go
@@ -86,6 +86,8 @@ func testAccResourceVariable_Full_CompanyContext(t *testing.T, withBootstrapConf
 
 	name := resourceName
 
+	var variableID, environmentID string
+
 	fullStep := resource.TestStep{
 		Config: testAccResourceVariable_CompanyContext_Full_Hcl(resourceName, name, withBootstrapConfig),
 		Check: resource.ComposeTestCheckFunc(
@@ -119,6 +121,45 @@ func testAccResourceVariable_Full_CompanyContext(t *testing.T, withBootstrapConf
 			resource.TestCheckResourceAttr(resourceFullName, "mutable", "true"),
 		),
 	}
+	
+	secretDynamicStep := resource.TestStep{
+		Config: testAccResourceVariable_CompanyContext_SecretDynamic_Hcl(resourceName, name, withBootstrapConfig),
+		Check: resource.ComposeTestCheckFunc(
+			davinci.Variable_GetIDs(resourceFullName, &environmentID, &variableID),
+			resource.TestMatchResourceAttr(resourceFullName, "id", regexp.MustCompile(`^[a-zA-Z0-9]+##SK##company$`)),
+			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckResourceAttr(resourceFullName, "name", name),
+			resource.TestCheckResourceAttr(resourceFullName, "context", "company"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "description"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "value"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "empty_value"),
+			resource.TestCheckResourceAttr(resourceFullName, "type", "secret"),
+			resource.TestCheckResourceAttr(resourceFullName, "min", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "max", "2000"),
+			resource.TestCheckResourceAttr(resourceFullName, "mutable", "true"),
+		),
+	}
+	
+	secretStaticStep := resource.TestStep{
+		Config: testAccResourceVariable_CompanyContext_SecretStatic_Hcl(resourceName, name, withBootstrapConfig),
+		Check: resource.ComposeTestCheckFunc(
+			davinci.Variable_GetIDs(resourceFullName, &environmentID, &variableID),
+			resource.TestMatchResourceAttr(resourceFullName, "id", regexp.MustCompile(`^[a-zA-Z0-9]+##SK##company$`)),
+			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckResourceAttr(resourceFullName, "name", name),
+			resource.TestCheckResourceAttr(resourceFullName, "context", "company"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "description"),
+			resource.TestCheckResourceAttr(resourceFullName, "value", "mysecret"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "empty_value"),
+			resource.TestCheckResourceAttr(resourceFullName, "type", "secret"),
+			resource.TestCheckResourceAttr(resourceFullName, "min", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "max", "2000"),
+			resource.TestCheckResourceAttr(resourceFullName, "mutable", "true"),
+		),
+	}
+
+	variableName := name
+	mutable := true
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -150,6 +191,26 @@ func testAccResourceVariable_Full_CompanyContext(t *testing.T, withBootstrapConf
 					return true, nil // skip due to https://github.com/pingidentity/terraform-provider-davinci/issues/253
 				},
 			},
+			{
+				Config:  testAccResourceVariable_CompanyContext_Full_Hcl(resourceName, name, withBootstrapConfig),
+				Destroy: true,
+			},
+			// Test secret
+			secretDynamicStep,
+			{
+				Config: testAccResourceVariable_CompanyContext_SecretDynamic_Hcl(resourceName, name, withBootstrapConfig),
+				PreConfig: func() {
+					davinci.Variable_RandomVariableValue_PreConfig(t, environmentID, nil, &dv.VariablePayload{
+						Name:    &variableName,
+						Context: "company",
+						Type:    "secret",
+						Mutable: &mutable,
+					})
+				},
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
+			secretStaticStep,
 			fullStep,
 			// Test importing the resource
 			{
@@ -648,6 +709,35 @@ func testAccResourceVariable_CompanyContext_Full_Hcl(resourceName, name string, 
 
 func testAccResourceVariable_CompanyContext_Minimal_Hcl(resourceName, name string, withBootstrapConfig bool) (hcl string) {
 	return testAccResourceVariable_Minimal_Hcl(resourceName, name, "company", withBootstrapConfig)
+}
+
+func testAccResourceVariable_CompanyContext_SecretDynamic_Hcl(resourceName, name string, withBootstrapConfig bool) (hcl string) {
+	context := "company"
+	return fmt.Sprintf(`
+%[1]s
+
+resource "davinci_variable" "%[2]s" {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[3]s"
+  context        = "%[4]s"
+  type           = "secret"
+}
+`, acctest.PingoneEnvironmentSsoHcl(resourceName, withBootstrapConfig), resourceName, name, context)
+}
+
+func testAccResourceVariable_CompanyContext_SecretStatic_Hcl(resourceName, name string, withBootstrapConfig bool) (hcl string) {
+	context := "company"
+	return fmt.Sprintf(`
+%[1]s
+
+resource "davinci_variable" "%[2]s" {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[3]s"
+  context        = "%[4]s"
+  type           = "secret"
+  value = "mysecret"
+}
+`, acctest.PingoneEnvironmentSsoHcl(resourceName, withBootstrapConfig), resourceName, name, context)
 }
 
 func testAccResourceVariable_FlowInstanceContext_Full_Hcl(resourceName, name string, withBootstrapConfig bool) (hcl string) {

--- a/internal/service/davinci/resource_variable_test.go
+++ b/internal/service/davinci/resource_variable_test.go
@@ -121,7 +121,7 @@ func testAccResourceVariable_Full_CompanyContext(t *testing.T, withBootstrapConf
 			resource.TestCheckResourceAttr(resourceFullName, "mutable", "true"),
 		),
 	}
-	
+
 	secretDynamicStep := resource.TestStep{
 		Config: testAccResourceVariable_CompanyContext_SecretDynamic_Hcl(resourceName, name, withBootstrapConfig),
 		Check: resource.ComposeTestCheckFunc(
@@ -139,7 +139,7 @@ func testAccResourceVariable_Full_CompanyContext(t *testing.T, withBootstrapConf
 			resource.TestCheckResourceAttr(resourceFullName, "mutable", "true"),
 		),
 	}
-	
+
 	secretStaticStep := resource.TestStep{
 		Config: testAccResourceVariable_CompanyContext_SecretStatic_Hcl(resourceName, name, withBootstrapConfig),
 		Check: resource.ComposeTestCheckFunc(
@@ -735,7 +735,7 @@ resource "davinci_variable" "%[2]s" {
   name           = "%[3]s"
   context        = "%[4]s"
   type           = "secret"
-  value = "mysecret"
+  value          = "mysecret"
 }
 `, acctest.PingoneEnvironmentSsoHcl(resourceName, withBootstrapConfig), resourceName, name, context)
 }


### PR DESCRIPTION
- `resource/davinci_variable`: Fix "Provider produced inconsistent result after apply" when defining a variable of `type` = `secret`.


### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccResourceVariable_ github.com/pingidentity/terraform-provider-davinci/internal/service/davinci
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccResourceVariable_RemovalDrift
=== PAUSE TestAccResourceVariable_RemovalDrift
=== RUN   TestAccResourceVariable_Full_CompanyContext_Clean
=== PAUSE TestAccResourceVariable_Full_CompanyContext_Clean
=== RUN   TestAccResourceVariable_Full_CompanyContext_WithBootstrap
=== PAUSE TestAccResourceVariable_Full_CompanyContext_WithBootstrap
=== RUN   TestAccResourceVariable_Full_FlowInstanceContext_Clean
=== PAUSE TestAccResourceVariable_Full_FlowInstanceContext_Clean
=== RUN   TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
=== PAUSE TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
=== RUN   TestAccResourceVariable_Full_UserContext_Clean
=== PAUSE TestAccResourceVariable_Full_UserContext_Clean
=== RUN   TestAccResourceVariable_Full_UserContext_WithBootstrap
=== PAUSE TestAccResourceVariable_Full_UserContext_WithBootstrap
=== RUN   TestAccResourceVariable_ChangeDataType
=== PAUSE TestAccResourceVariable_ChangeDataType
=== RUN   TestAccResourceVariable_Values_CompanyContext
=== PAUSE TestAccResourceVariable_Values_CompanyContext
=== RUN   TestAccResourceVariable_Values_FlowInstanceContext
=== PAUSE TestAccResourceVariable_Values_FlowInstanceContext
=== RUN   TestAccResourceVariable_Values_FlowContext
=== PAUSE TestAccResourceVariable_Values_FlowContext
=== RUN   TestAccResourceVariable_BadParameters
=== PAUSE TestAccResourceVariable_BadParameters
=== CONT  TestAccResourceVariable_RemovalDrift
=== CONT  TestAccResourceVariable_Full_UserContext_WithBootstrap
=== CONT  TestAccResourceVariable_Values_FlowContext
=== CONT  TestAccResourceVariable_Values_CompanyContext
=== CONT  TestAccResourceVariable_ChangeDataType
=== CONT  TestAccResourceVariable_Full_FlowInstanceContext_Clean
=== CONT  TestAccResourceVariable_Full_CompanyContext_WithBootstrap
=== CONT  TestAccResourceVariable_Full_CompanyContext_Clean
=== CONT  TestAccResourceVariable_Full_UserContext_Clean
=== CONT  TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
=== CONT  TestAccResourceVariable_Values_FlowInstanceContext
=== CONT  TestAccResourceVariable_BadParameters
=== NAME  TestAccResourceVariable_RemovalDrift
    resource_variable_test.go:33: Skipping step 3/4 due to SkipFunc
    resource_variable_test.go:33: Skipping step 4/4 due to SkipFunc
--- PASS: TestAccResourceVariable_RemovalDrift (152.80s)
--- PASS: TestAccResourceVariable_BadParameters (248.57s)
--- PASS: TestAccResourceVariable_ChangeDataType (260.08s)
=== NAME  TestAccResourceVariable_Full_UserContext_WithBootstrap
    resource_variable_test.go:392: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_FlowInstanceContext_Clean
    resource_variable_test.go:288: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_UserContext_Clean
    resource_variable_test.go:392: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_CompanyContext_Clean
    resource_variable_test.go:164: Skipping step 6/12 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_CompanyContext_WithBootstrap
    resource_variable_test.go:164: Skipping step 6/12 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
    resource_variable_test.go:288: Skipping step 6/8 due to SkipFunc
--- PASS: TestAccResourceVariable_Full_UserContext_Clean (435.89s)
--- PASS: TestAccResourceVariable_Full_UserContext_WithBootstrap (438.40s)
--- PASS: TestAccResourceVariable_Full_FlowInstanceContext_Clean (438.61s)
--- PASS: TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap (443.20s)
--- PASS: TestAccResourceVariable_Full_CompanyContext_Clean (510.35s)
--- PASS: TestAccResourceVariable_Full_CompanyContext_WithBootstrap (517.97s)
--- PASS: TestAccResourceVariable_Values_FlowContext (562.91s)
--- PASS: TestAccResourceVariable_Values_FlowInstanceContext (565.23s)
--- PASS: TestAccResourceVariable_Values_CompanyContext (576.04s)
PASS
ok      github.com/pingidentity/terraform-provider-davinci/internal/service/davinci     578.296s
```

</details>