### PR TITLE
Flow variable import and data type fixes

### DIFF
--- a/.changelog/361.txt
+++ b/.changelog/361.txt
@@ -6,6 +6,14 @@
 `resource/davinci_variable`: Fixed "Error reading variable: json: cannot unmarshal object into Go struct field" error on all variables when a flow sets a flow variable value to an object type.
 ```
 
+```release-note:breaking-change
+`resource/davinci_flow`: Reverted the ability to use flow exports with variable values removed.  Variable values are required when importing flows using this provider.
+```
+
 ```release-note:bug
-`resource/davinci_flow`: Fixed issue on import where flow and flow instance variables lose their value setting when using the Variables Connector node.
+`resource/davinci_flow`: Resolve warnings that state that DaVinci JSON files contain unknown properties when using flow variable nodes.
+```
+
+```release-note:note
+`resource/davinci_flow`: Enhanced errors that result from invalid flow formats.
 ```

--- a/.changelog/361.txt
+++ b/.changelog/361.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+`resource/davinci_variable`: Fixed panic crash when attempting to create a new flow variable that does not already exist.
+```
+
+```release-note:bug
+`resource/davinci_variable`: Fixed "Error reading variable: json: cannot unmarshal object into Go struct field" error on all variables when a flow sets a flow variable value to an object type.
+```
+
+```release-note:bug
+`resource/davinci_flow`: Fixed issue on import where flow and flow instance variables lose their value setting when using the Variables Connector node.
+```

--- a/.changelog/361.txt
+++ b/.changelog/361.txt
@@ -15,5 +15,5 @@
 ```
 
 ```release-note:note
-`resource/davinci_flow`: Enhanced errors that result from invalid flow formats.
+`resource/davinci_flow`: Enhanced error messages that result from invalid flow formats.
 ```

--- a/.changelog/361.txt
+++ b/.changelog/361.txt
@@ -17,3 +17,7 @@
 ```release-note:note
 `resource/davinci_flow`: Enhanced error messages that result from invalid flow formats.
 ```
+
+```release-note:note
+Bump `github.com/samir-gandhi/davinci-client-go` from 0.4.0 => 0.5.0
+```

--- a/docs/resources/flow.md
+++ b/docs/resources/flow.md
@@ -9,6 +9,8 @@ description: |-
 
 Resource to import and manage a DaVinci flow in an environment.  Connection and Subflow references in the JSON export can be overridden with ones managed by Terraform, see the examples and schema below for details.
 
+!> Only flows that include variable values are supported. Flows that have been exported from a source system with the "Include Variable Values" admin console tickbox unchecked will not be imported correctly.
+
 !> When flow, flow instance or company variables are embedded in the `flow_json`, only the `context`, `type` and `name` of the variables are managed by this resource.  To manage the mutability, value, description, minimum and maximum values of an imported variable, the `davinci_variable` resource must be used.
 
 ~> When using "company" or "flow instance" variables, it is recommended to define these variables using the `davinci_variable` resource before the flows that depend on them. This is shown in the example using the `depends_on` meta argument.

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/patrickcping/pingone-go-sdk-v2 v0.12.3
 	github.com/patrickcping/pingone-go-sdk-v2/management v0.43.0
 	github.com/pavius/impi v0.0.3
-	github.com/samir-gandhi/davinci-client-go v0.4.0
+	github.com/samir-gandhi/davinci-client-go v0.5.0
 	github.com/samir-gandhi/dvgenerate v0.0.11
 	github.com/terraform-linters/tflint v0.53.0
 )

--- a/go.sum
+++ b/go.sum
@@ -929,8 +929,8 @@ github.com/ryancurrah/gomodguard v1.3.3 h1:eiSQdJVNr9KTNxY2Niij8UReSwR8Xrte3exBr
 github.com/ryancurrah/gomodguard v1.3.3/go.mod h1:rsKQjj4l3LXe8N344Ow7agAy5p9yjsWOtRzUMYmA0QY=
 github.com/ryanrolds/sqlclosecheck v0.5.1 h1:dibWW826u0P8jNLsLN+En7+RqWWTYrjCB9fJfSfdyCU=
 github.com/ryanrolds/sqlclosecheck v0.5.1/go.mod h1:2g3dUjoS6AL4huFdv6wn55WpLIDjY7ZgUR4J8HOO/XQ=
-github.com/samir-gandhi/davinci-client-go v0.4.0 h1:XsjCOxZhm9AvhVREUuqFP09dMjHwnsk4pDAx6uPzaUk=
-github.com/samir-gandhi/davinci-client-go v0.4.0/go.mod h1:DmOPy/WsIc4e7RYOIeSGM6Qrlb1JsYuN45UaGnlDt9U=
+github.com/samir-gandhi/davinci-client-go v0.5.0 h1:8aYXLsfdepnR5seT7suqI2WTQkhueX/8KzvevHy5LBA=
+github.com/samir-gandhi/davinci-client-go v0.5.0/go.mod h1:DmOPy/WsIc4e7RYOIeSGM6Qrlb1JsYuN45UaGnlDt9U=
 github.com/samir-gandhi/dvgenerate v0.0.11 h1:VMvkeCdI7DyzrPuE3clPFPvR1gO9s6Z24O8Gyh0d5h8=
 github.com/samir-gandhi/dvgenerate v0.0.11/go.mod h1:PvrK6c+8SdRSWKmyXsagKeVqSGoo9P8oBbWaIzFD1mQ=
 github.com/sanposhiho/wastedassign/v2 v2.0.7 h1:J+6nrY4VW+gC9xFzUc+XjPD3g3wF3je/NsJFwFK7Uxc=

--- a/internal/acctest/flows/full-basic-novariablevalues.json
+++ b/internal/acctest/flows/full-basic-novariablevalues.json
@@ -1,5 +1,5 @@
 {
-  "companyId": "942b4724-d83d-418c-966c-ed7d352a985c",
+  "companyId": "2c6123ae-108f-4d11-bcc2-6c8f4dfa9fdb",
   "authTokenExpireIds": [],
   "connectorIds": [
     "httpConnector",
@@ -8,19 +8,19 @@
     "flowConnector",
     "variablesConnector"
   ],
-  "createdDate": 1723638023970,
-  "currentVersion": 1,
+  "createdDate": 1706708769850,
+  "currentVersion": 8,
   "customerId": "db5f4450b2bd8a56ce076dec0c358a9a",
-  "deployedDate": 1723638024066,
-  "description": "Imported on Wed Aug 14 2024 12:20:23 GMT+0000 (Coordinated Universal Time)",
+  "deployedDate": 1706709739837,
+  "description": "",
   "flowStatus": "enabled",
   "isOutputSchemaSaved": false,
   "name": "full-basic",
-  "publishedVersion": 1,
+  "publishedVersion": 8,
   "timeouts": "null",
-  "updatedDate": 1723638024104,
-  "flowId": "8236d08b476a5cf7b981fa53f6971019",
-  "versionId": 1,
+  "updatedDate": 1706709739837,
+  "flowId": "c7062a8857740ee2185694bb855f8f21",
+  "versionId": 8,
   "graphData": {
     "elements": {
       "nodes": [
@@ -28,9 +28,9 @@
           "data": {
             "id": "1u2m5vzr49",
             "nodeType": "CONNECTION",
-            "connectionId": "481e952e6b11db8360587b8711620786",
+            "connectionId": "867ed4363b2bc21c860085ad2baa817d",
             "connectorId": "httpConnector",
-            "name": "HTTP",
+            "name": "Http",
             "label": "Http",
             "status": "configured",
             "capabilityName": "customHtmlMessage",
@@ -77,9 +77,9 @@
           "data": {
             "id": "nx0o1b2cmw",
             "nodeType": "CONNECTION",
-            "connectionId": "548ea933f35b9787ae12ad130f78045b",
+            "connectionId": "de650ca45593b82c49064ead10b9fe17",
             "connectorId": "functionsConnector",
-            "name": "abcd123-functions",
+            "name": "Functions",
             "label": "Functions",
             "status": "configured",
             "capabilityName": "AEqualsB",
@@ -137,9 +137,9 @@
           "data": {
             "id": "ikt13crnhy",
             "nodeType": "CONNECTION",
-            "connectionId": "481e952e6b11db8360587b8711620786",
+            "connectionId": "867ed4363b2bc21c860085ad2baa817d",
             "connectorId": "httpConnector",
-            "name": "HTTP",
+            "name": "Http",
             "label": "Http",
             "status": "configured",
             "capabilityName": "createSuccessResponse",
@@ -163,9 +163,9 @@
           "data": {
             "id": "vsp1ewtr9m",
             "nodeType": "CONNECTION",
-            "connectionId": "fa497c1ceaea43c0886d8d360874a53d",
+            "connectionId": "53ab83a4a4ab919d9f2cb02d9e111ac8",
             "connectorId": "errorConnector",
-            "name": "abcd123-error",
+            "name": "Error Message",
             "label": "Error Message",
             "status": "configured",
             "capabilityName": "customErrorMessage",
@@ -193,9 +193,9 @@
           "data": {
             "id": "xb74p6rkd8",
             "nodeType": "CONNECTION",
-            "connectionId": "84e29d2409ba66c0caf53f9cad0a2049",
+            "connectionId": "2581eb287bb1d9bd29ae9886d675f89f",
             "connectorId": "flowConnector",
-            "name": "abcd123-flow",
+            "name": "Flow Connector",
             "label": "Flow Conductor",
             "status": "configured",
             "capabilityName": "startUiSubFlow",
@@ -229,9 +229,9 @@
           "data": {
             "id": "kq5ybvwvro",
             "nodeType": "CONNECTION",
-            "connectionId": "84e29d2409ba66c0caf53f9cad0a2049",
+            "connectionId": "2581eb287bb1d9bd29ae9886d675f89f",
             "connectorId": "flowConnector",
-            "name": "abcd123-flow",
+            "name": "Flow Connector",
             "label": "Flow Conductor",
             "status": "configured",
             "capabilityName": "startUiSubFlow",
@@ -301,9 +301,9 @@
           "data": {
             "id": "3zvjdgdljx",
             "nodeType": "CONNECTION",
-            "connectionId": "9f8f97e94ad87e184960633b424d80b6",
+            "connectionId": "06922a684039827499bdbdd97f49827b",
             "connectorId": "variablesConnector",
-            "name": "abcd123-variables",
+            "name": "Variables",
             "label": "Variables",
             "status": "configured",
             "capabilityName": "saveFlowValue",
@@ -589,11 +589,12 @@
     }
   },
   "flowColor": "#E3F0FF",
-  "savedDate": 1723638023903,
+  "savedDate": 1706708769645,
   "variables": [
     {
       "context": "flow",
-      "createdDate": 1723638023769,
+      "createdDate": 1706708735989,
+      "customerId": "db5f4450b2bd8a56ce076dec0c358a9a",
       "fields": {
         "type": "string",
         "displayName": "",
@@ -601,16 +602,16 @@
         "min": 0,
         "max": 2000
       },
-      "flowId": "8236d08b476a5cf7b981fa53f6971019",
-      "id": "bfaf14e8-0756-4e78-800e-90f558391368",
+      "flowId": "c7062a8857740ee2185694bb855f8f21",
       "type": "property",
       "visibility": "private",
-      "name": "fdgdfgfdg##SK##flow##SK##8236d08b476a5cf7b981fa53f6971019",
-      "companyId": "942b4724-d83d-418c-966c-ed7d352a985c"
+      "name": "fdgdfgfdg##SK##flow##SK##c7062a8857740ee2185694bb855f8f21",
+      "companyId": "2c6123ae-108f-4d11-bcc2-6c8f4dfa9fdb"
     },
     {
       "context": "flow",
-      "createdDate": 1723638023768,
+      "createdDate": 1706708761083,
+      "customerId": "db5f4450b2bd8a56ce076dec0c358a9a",
       "fields": {
         "type": "number",
         "displayName": "test123",
@@ -618,12 +619,11 @@
         "min": 4,
         "max": 20
       },
-      "flowId": "8236d08b476a5cf7b981fa53f6971019",
-      "id": "0389e818-4dd2-4203-b82f-ee5948f93287",
+      "flowId": "c7062a8857740ee2185694bb855f8f21",
       "type": "property",
       "visibility": "private",
-      "name": "test123##SK##flow##SK##8236d08b476a5cf7b981fa53f6971019",
-      "companyId": "942b4724-d83d-418c-966c-ed7d352a985c"
+      "name": "test123##SK##flow##SK##c7062a8857740ee2185694bb855f8f21",
+      "companyId": "2c6123ae-108f-4d11-bcc2-6c8f4dfa9fdb"
     }
   ],
   "connections": []

--- a/internal/acctest/flows/full-basic-vars-add-variable.json
+++ b/internal/acctest/flows/full-basic-vars-add-variable.json
@@ -315,19 +315,22 @@
                     "name": "fdgdfgfdg",
                     "key": 0.8936786494474329,
                     "label": "fdgdfgfdg (string - flow)",
-                    "type": "string"
+                    "type": "string",
+                    "value": "fdgdfgfdgValue"
                   },
                   {
                     "name": "fdgdfgfdgNEW",
                     "key": 0.8936786494474330,
                     "label": "fdgdfgfdgNEW (string - flow)",
-                    "type": "string"
+                    "type": "string",
+                    "value": "fdgdfgfdgNEWValue"
                   },
                   {
                     "name": "test123",
                     "key": 0.379286774724122,
                     "label": "test123 (number - flow)",
-                    "type": "number"
+                    "type": "number",
+                    "value": 5
                   }
                 ]
               }
@@ -382,7 +385,8 @@
                     "name": "flowInstanceVariable1",
                     "key": 0.09068454768967449,
                     "label": "flowInstanceVariable1 (string - flowInstance)",
-                    "type": "string"
+                    "type": "string",
+                    "value": "flowInstanceVariable1Value"
                   }
                 ]
               }
@@ -437,7 +441,8 @@
                     "name": "testuser",
                     "key": 0.9814043007447408,
                     "label": "testuser (string - flowInstance)",
-                    "type": "string"
+                    "type": "string",
+                    "value": "testuserValue"
                   }
                 ]
               }

--- a/internal/acctest/flows/full-basic-vars-modify-variable.json
+++ b/internal/acctest/flows/full-basic-vars-modify-variable.json
@@ -315,13 +315,15 @@
                     "name": "fdgdfgfdg",
                     "key": 0.8936786494474329,
                     "label": "fdgdfgfdg (number - flow)",
-                    "type": "number"
+                    "type": "number",
+                    "value": 10
                   },
                   {
                     "name": "test123",
                     "key": 0.379286774724122,
                     "label": "test123 (number - flow)",
-                    "type": "number"
+                    "type": "number",
+                    "value": 5
                   }
                 ]
               }
@@ -376,7 +378,8 @@
                     "name": "flowInstanceVariable1",
                     "key": 0.09068454768967449,
                     "label": "flowInstanceVariable1 (string - flowInstance)",
-                    "type": "string"
+                    "type": "string",
+                    "value": "flowInstanceVariable1Value"
                   }
                 ]
               }
@@ -431,7 +434,8 @@
                     "name": "testuser",
                     "key": 0.9814043007447408,
                     "label": "testuser (string - flowInstance)",
-                    "type": "string"
+                    "type": "string",
+                    "value": "testuserValue"
                   }
                 ]
               }

--- a/internal/acctest/flows/full-basic-vars-remove-variable.json
+++ b/internal/acctest/flows/full-basic-vars-remove-variable.json
@@ -315,7 +315,8 @@
                     "name": "test123",
                     "key": 0.379286774724122,
                     "label": "test123 (number - flow)",
-                    "type": "number"
+                    "type": "number",
+                    "value": 5
                   }
                 ]
               }
@@ -370,7 +371,8 @@
                     "name": "flowInstanceVariable1",
                     "key": 0.09068454768967449,
                     "label": "flowInstanceVariable1 (string - flowInstance)",
-                    "type": "string"
+                    "type": "string",
+                    "value": "flowInstanceVariable1Value"
                   }
                 ]
               }
@@ -425,7 +427,8 @@
                     "name": "testuser",
                     "key": 0.9814043007447408,
                     "label": "testuser (string - flowInstance)",
-                    "type": "string"
+                    "type": "string",
+                    "value": "testuserValue"
                   }
                 ]
               }

--- a/internal/acctest/flows/full-basic-vars.json
+++ b/internal/acctest/flows/full-basic-vars.json
@@ -315,13 +315,15 @@
                     "name": "fdgdfgfdg",
                     "key": 0.8936786494474329,
                     "label": "fdgdfgfdg (string - flow)",
-                    "type": "string"
+                    "type": "string",
+                    "value": "fdgdfgfdgValue"
                   },
                   {
                     "name": "test123",
                     "key": 0.379286774724122,
                     "label": "test123 (number - flow)",
-                    "type": "number"
+                    "type": "number",
+                    "value": "5"
                   }
                 ]
               }
@@ -376,7 +378,8 @@
                     "name": "flowInstanceVariable1",
                     "key": 0.09068454768967449,
                     "label": "flowInstanceVariable1 (string - flowInstance)",
-                    "type": "string"
+                    "type": "string",
+                    "value": "flowInstanceVariable1Value"
                   }
                 ]
               }
@@ -431,7 +434,8 @@
                     "name": "testuser",
                     "key": 0.9814043007447408,
                     "label": "testuser (string - flowInstance)",
-                    "type": "string"
+                    "type": "string",
+                    "value": "testuserValue"
                   }
                 ]
               }

--- a/internal/service/davinci/resource_flow.go
+++ b/internal/service/davinci/resource_flow.go
@@ -82,6 +82,11 @@ var (
 		IgnoreVersionMetadata:     true,
 		IgnoreFlowMetadata:        false,
 		IgnoreFlowVariables:       false,
+		NodeOpts: &davinci.ExportNodeCmpOpts{
+			VariablesConnector: &davinci.ExportNodeVariablesCmpOpts{
+				ExpectVariableValues: true, // The input field needs validation
+			},
+		},
 	}
 
 	flowConfigurationJsonCmpOptsConfiguration = davinci.ExportCmpOpts{
@@ -92,6 +97,11 @@ var (
 		IgnoreVersionMetadata:     true,
 		IgnoreFlowMetadata:        true,
 		IgnoreFlowVariables:       true,
+		NodeOpts: &davinci.ExportNodeCmpOpts{
+			VariablesConnector: &davinci.ExportNodeVariablesCmpOpts{
+				ExpectVariableValues: false, // We don't need to validate this
+			},
+		},
 	}
 
 	flowExportJsonCmpOptsConfiguration = davinci.ExportCmpOpts{
@@ -102,6 +112,11 @@ var (
 		IgnoreVersionMetadata:     false,
 		IgnoreFlowMetadata:        false,
 		IgnoreFlowVariables:       true, // because this is handled by another resource
+		NodeOpts: &davinci.ExportNodeCmpOpts{
+			VariablesConnector: &davinci.ExportNodeVariablesCmpOpts{
+				ExpectVariableValues: false, // We don't need to validate this
+			},
+		},
 	}
 )
 

--- a/internal/service/davinci/resource_flow.go
+++ b/internal/service/davinci/resource_flow.go
@@ -657,7 +657,7 @@ func (r *FlowResource) Create(ctx context.Context, req resource.CreateRequest, r
 		r.Client,
 		environmentID,
 		func() (interface{}, *http.Response, error) {
-			return r.Client.ReadFlowVersionOptionalVariableWithResponse(environmentID, createFlow.FlowID, nil, false)
+			return r.Client.ReadFlowVersionOptionalVariableWithResponse(environmentID, createFlow.FlowID, nil, true)
 		},
 	)
 	if err != nil {
@@ -710,7 +710,7 @@ func (r *FlowResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		r.Client,
 		environmentID,
 		func() (interface{}, *http.Response, error) {
-			return r.Client.ReadFlowVersionOptionalVariableWithResponse(environmentID, flowID, nil, false)
+			return r.Client.ReadFlowVersionOptionalVariableWithResponse(environmentID, flowID, nil, true)
 		},
 	)
 
@@ -893,7 +893,7 @@ func (r *FlowResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		r.Client,
 		environmentID,
 		func() (interface{}, *http.Response, error) {
-			return r.Client.ReadFlowVersionOptionalVariableWithResponse(environmentID, flowID, nil, false)
+			return r.Client.ReadFlowVersionOptionalVariableWithResponse(environmentID, flowID, nil, true)
 		},
 	)
 	if err != nil {

--- a/internal/service/davinci/resource_variable.go
+++ b/internal/service/davinci/resource_variable.go
@@ -733,9 +733,9 @@ func (p *VariableResourceModel) toState(apiObject map[string]davinci.Variable) d
 
 		value := ""
 		// switch type of v
-		switch v.(type) {
+		switch v := v.(type) {
 		case string:
-			value = v.(string)
+			value = v
 			value = regexp.MustCompile(`^\*+$`).ReplaceAllString(value, p.Value.ValueString())
 		case bool:
 			value = fmt.Sprintf("%v", v)

--- a/templates/resources/flow.md.tmpl
+++ b/templates/resources/flow.md.tmpl
@@ -9,6 +9,8 @@ description: |-
 
 {{ .Description | trimspace }}
 
+!> Only flows that include variable values are supported. Flows that have been exported from a source system with the "Include Variable Values" admin console tickbox unchecked will not be imported correctly.
+
 !> When flow, flow instance or company variables are embedded in the `flow_json`, only the `context`, `type` and `name` of the variables are managed by this resource.  To manage the mutability, value, description, minimum and maximum values of an imported variable, the `davinci_variable` resource must be used.
 
 ~> When using "company" or "flow instance" variables, it is recommended to define these variables using the `davinci_variable` resource before the flows that depend on them. This is shown in the example using the `depends_on` meta argument.


### PR DESCRIPTION
### Changes

**BREAKING CHANGE** `resource/davinci_flow`: Reverted the ability to use flow exports with variable values removed.  Variable values are required when importing flows using this provider.
**BUG FIX** `resource/davinci_variable`: Fixed panic crash when attempting to create a new flow variable that does not already exist.
**BUG FIX** `resource/davinci_variable`: Fixed "Error reading variable: json: cannot unmarshal object into Go struct field" error on all variables when a flow sets a flow variable value to an object type.
**BUG FIX** `resource/davinci_flow`: Resolve warnings that state that DaVinci JSON files contain unknown properties when using flow variable nodes.
`resource/davinci_flow`: Enhanced error messages that result from invalid flow formats.

### SDK Update Needed

Requires `github.com/samir-gandhi/davinci-client-go` `v0.5.0`

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccResourceVariable_ github.com/pingidentity/terraform-provider-davinci/internal/service/davinci && \
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccResourceFlow_ github.com/pingidentity/terraform-provider-davinci/internal/service/davinci
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccResourceVariable_RemovalDrift
=== PAUSE TestAccResourceVariable_RemovalDrift
=== RUN   TestAccResourceVariable_Full_CompanyContext_Clean
=== PAUSE TestAccResourceVariable_Full_CompanyContext_Clean
=== RUN   TestAccResourceVariable_Full_CompanyContext_WithBootstrap
=== PAUSE TestAccResourceVariable_Full_CompanyContext_WithBootstrap
=== RUN   TestAccResourceVariable_Full_FlowInstanceContext_Clean
=== PAUSE TestAccResourceVariable_Full_FlowInstanceContext_Clean
=== RUN   TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
=== PAUSE TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
=== RUN   TestAccResourceVariable_Full_UserContext_Clean
=== PAUSE TestAccResourceVariable_Full_UserContext_Clean
=== RUN   TestAccResourceVariable_Full_UserContext_WithBootstrap
=== PAUSE TestAccResourceVariable_Full_UserContext_WithBootstrap
=== RUN   TestAccResourceVariable_ChangeDataType
=== PAUSE TestAccResourceVariable_ChangeDataType
=== RUN   TestAccResourceVariable_Values_CompanyContext
=== PAUSE TestAccResourceVariable_Values_CompanyContext
=== RUN   TestAccResourceVariable_Values_FlowInstanceContext
=== PAUSE TestAccResourceVariable_Values_FlowInstanceContext
=== RUN   TestAccResourceVariable_Values_FlowContext
=== PAUSE TestAccResourceVariable_Values_FlowContext
=== RUN   TestAccResourceVariable_BadParameters
=== PAUSE TestAccResourceVariable_BadParameters
=== CONT  TestAccResourceVariable_RemovalDrift
=== CONT  TestAccResourceVariable_Full_UserContext_WithBootstrap
=== CONT  TestAccResourceVariable_Values_FlowInstanceContext
=== CONT  TestAccResourceVariable_BadParameters
=== CONT  TestAccResourceVariable_Values_FlowContext
=== CONT  TestAccResourceVariable_Full_FlowInstanceContext_Clean
=== CONT  TestAccResourceVariable_Values_CompanyContext
=== CONT  TestAccResourceVariable_Full_CompanyContext_WithBootstrap
=== CONT  TestAccResourceVariable_Full_CompanyContext_Clean
=== CONT  TestAccResourceVariable_Full_UserContext_Clean
=== CONT  TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
=== CONT  TestAccResourceVariable_ChangeDataType
=== NAME  TestAccResourceVariable_RemovalDrift
    resource_variable_test.go:33: Skipping step 3/4 due to SkipFunc
    resource_variable_test.go:33: Skipping step 4/4 due to SkipFunc
--- PASS: TestAccResourceVariable_RemovalDrift (129.15s)
--- PASS: TestAccResourceVariable_BadParameters (182.83s)
--- PASS: TestAccResourceVariable_ChangeDataType (217.14s)
=== NAME  TestAccResourceVariable_Full_FlowInstanceContext_Clean
    resource_variable_test.go:288: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_CompanyContext_Clean
    resource_variable_test.go:164: Skipping step 6/12 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_UserContext_WithBootstrap
    resource_variable_test.go:392: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_CompanyContext_WithBootstrap
    resource_variable_test.go:164: Skipping step 6/12 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
    resource_variable_test.go:288: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_UserContext_Clean
    resource_variable_test.go:392: Skipping step 6/8 due to SkipFunc
--- PASS: TestAccResourceVariable_Full_FlowInstanceContext_Clean (393.62s)
--- PASS: TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap (398.56s)
--- PASS: TestAccResourceVariable_Full_UserContext_WithBootstrap (399.20s)
--- PASS: TestAccResourceVariable_Full_UserContext_Clean (401.04s)
--- PASS: TestAccResourceVariable_Full_CompanyContext_Clean (465.52s)
--- PASS: TestAccResourceVariable_Full_CompanyContext_WithBootstrap (469.95s)
--- PASS: TestAccResourceVariable_Values_CompanyContext (513.62s)
--- PASS: TestAccResourceVariable_Values_FlowContext (515.57s)
--- PASS: TestAccResourceVariable_Values_FlowInstanceContext (520.83s)
PASS
ok      github.com/pingidentity/terraform-provider-davinci/internal/service/davinci     522.163s
=== RUN   TestAccResourceFlow_RemovalDrift
=== PAUSE TestAccResourceFlow_RemovalDrift
=== RUN   TestAccResourceFlow_Basic_Clean
=== PAUSE TestAccResourceFlow_Basic_Clean
=== RUN   TestAccResourceFlow_Basic_WithBootstrap
=== PAUSE TestAccResourceFlow_Basic_WithBootstrap
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== RUN   TestAccResourceFlow_ComputeDifferences_ModifySettings
=== PAUSE TestAccResourceFlow_ComputeDifferences_ModifySettings
=== RUN   TestAccResourceFlow_ComputeDifferences_CompanyId
=== PAUSE TestAccResourceFlow_ComputeDifferences_CompanyId
=== RUN   TestAccResourceFlow_ComputeDifferences_Version
=== PAUSE TestAccResourceFlow_ComputeDifferences_Version
=== RUN   TestAccResourceFlow_ComputeDifferences_Description
=== PAUSE TestAccResourceFlow_ComputeDifferences_Description
=== RUN   TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== PAUSE TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== RUN   TestAccResourceFlow_ComputeDifferences_NewNode
=== PAUSE TestAccResourceFlow_ComputeDifferences_NewNode
=== RUN   TestAccResourceFlow_UnknownFlowString
=== PAUSE TestAccResourceFlow_UnknownFlowString
=== RUN   TestAccResourceFlow_BrokenFlow
=== PAUSE TestAccResourceFlow_BrokenFlow
=== RUN   TestAccResourceFlow_Variables_Clean
=== PAUSE TestAccResourceFlow_Variables_Clean
=== RUN   TestAccResourceFlow_Variables_WithBootstrap
=== PAUSE TestAccResourceFlow_Variables_WithBootstrap
=== RUN   TestAccResourceFlow_Variables_Invalid
=== PAUSE TestAccResourceFlow_Variables_Invalid
=== RUN   TestAccResourceFlow_Variables_Overridden_Clean
=== PAUSE TestAccResourceFlow_Variables_Overridden_Clean
=== RUN   TestAccResourceFlow_Variables_Overridden_WithBootstrap
=== PAUSE TestAccResourceFlow_Variables_Overridden_WithBootstrap
=== RUN   TestAccResourceFlow_BadParameters
=== PAUSE TestAccResourceFlow_BadParameters
=== CONT  TestAccResourceFlow_RemovalDrift
=== CONT  TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== CONT  TestAccResourceFlow_Variables_WithBootstrap
=== CONT  TestAccResourceFlow_Variables_Overridden_WithBootstrap
=== CONT  TestAccResourceFlow_ComputeDifferences_NewNode
=== CONT  TestAccResourceFlow_Variables_Overridden_Clean
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== CONT  TestAccResourceFlow_Variables_Clean
=== CONT  TestAccResourceFlow_BadParameters
=== CONT  TestAccResourceFlow_Variables_Invalid
=== CONT  TestAccResourceFlow_ComputeDifferences_Version
=== NAME  TestAccResourceFlow_Variables_Overridden_WithBootstrap
    resource_flow_test.go:1239: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_Variables_Overridden_WithBootstrap (0.02s)
=== NAME  TestAccResourceFlow_Variables_WithBootstrap
    resource_flow_test.go:1001: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_Variables_WithBootstrap (0.02s)
=== CONT  TestAccResourceFlow_UnknownFlowString
=== CONT  TestAccResourceFlow_ComputeDifferences_ModifySettings
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== CONT  TestAccResourceFlow_BrokenFlow
=== CONT  TestAccResourceFlow_ComputeDifferences_CompanyId
=== NAME  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
    resource_flow_test.go:323: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap (0.01s)
=== CONT  TestAccResourceFlow_ComputeDifferences_Description
--- PASS: TestAccResourceFlow_Variables_Invalid (26.98s)
=== CONT  TestAccResourceFlow_Basic_WithBootstrap
    resource_flow_test.go:178: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_Basic_WithBootstrap (0.01s)
=== CONT  TestAccResourceFlow_Basic_Clean
--- PASS: TestAccResourceFlow_BrokenFlow (228.43s)
=== NAME  TestAccResourceFlow_RemovalDrift
    resource_flow_test.go:39: Skipping step 3/4 due to SkipFunc
    resource_flow_test.go:39: Skipping step 4/4 due to SkipFunc
--- PASS: TestAccResourceFlow_UnknownFlowString (281.30s)
--- PASS: TestAccResourceFlow_RemovalDrift (292.52s)
=== NAME  TestAccResourceFlow_Variables_Clean
    resource_flow_test.go:995: Skipping step 2/4 due to SkipFunc
=== NAME  TestAccResourceFlow_Variables_Overridden_Clean
    resource_flow_test.go:1233: Skipping step 2/4 due to SkipFunc
--- PASS: TestAccResourceFlow_BadParameters (306.57s)
--- PASS: TestAccResourceFlow_ComputeDifferences_Version (324.10s)
--- PASS: TestAccResourceFlow_ComputeDifferences_AdditionalProperties (324.16s)
--- PASS: TestAccResourceFlow_ComputeDifferences_NewNode (325.42s)
--- PASS: TestAccResourceFlow_ComputeDifferences_CompanyId (328.33s)
--- PASS: TestAccResourceFlow_ComputeDifferences_ModifySettings (329.03s)
--- PASS: TestAccResourceFlow_ComputeDifferences_Description (329.91s)
--- PASS: TestAccResourceFlow_Variables_Clean (414.79s)
--- PASS: TestAccResourceFlow_Variables_Overridden_Clean (425.59s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean (592.64s)
--- PASS: TestAccResourceFlow_Basic_Clean (565.68s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean (594.24s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap (962.20s)
PASS
ok      github.com/pingidentity/terraform-provider-davinci/internal/service/davinci     963.251s
```

</details>