### PR TITLE
Remove node specific validation from the additional properties check

### DIFF
--- a/.changelog/363.txt
+++ b/.changelog/363.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/davinci_flow`: Remove node specific validation from the additional (unknown) properties validation check.
+```

--- a/internal/framework/customtypes/davinciexporttype/parsed_value.go
+++ b/internal/framework/customtypes/davinciexporttype/parsed_value.go
@@ -163,7 +163,6 @@ func (v ParsedValue) ValidateAttribute(ctx context.Context, req xattr.ValidateAt
 		IgnoreVersionMetadata:     true,
 		IgnoreFlowMetadata:        true,
 		IgnoreFlowVariables:       true,
-		NodeOpts:                  v.NodeOpts,
 	})
 
 	if !v.IgnoreUnmappedProperties && err != nil {


### PR DESCRIPTION
### Changes

**BUG FIX** `resource/davinci_flow`: Remove node specific validation from the additional (unknown) properties validation check.

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccResourceFlow_ github.com/pingidentity/terraform-provider-davinci/internal/service/davinci
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccResourceFlow_RemovalDrift
=== PAUSE TestAccResourceFlow_RemovalDrift
=== RUN   TestAccResourceFlow_Basic_Clean
=== PAUSE TestAccResourceFlow_Basic_Clean
=== RUN   TestAccResourceFlow_Basic_WithBootstrap
=== PAUSE TestAccResourceFlow_Basic_WithBootstrap
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== RUN   TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== PAUSE TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== RUN   TestAccResourceFlow_ComputeDifferences_ModifySettings
=== PAUSE TestAccResourceFlow_ComputeDifferences_ModifySettings
=== RUN   TestAccResourceFlow_ComputeDifferences_CompanyId
=== PAUSE TestAccResourceFlow_ComputeDifferences_CompanyId
=== RUN   TestAccResourceFlow_ComputeDifferences_Version
=== PAUSE TestAccResourceFlow_ComputeDifferences_Version
=== RUN   TestAccResourceFlow_ComputeDifferences_Description
=== PAUSE TestAccResourceFlow_ComputeDifferences_Description
=== RUN   TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== PAUSE TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== RUN   TestAccResourceFlow_ComputeDifferences_NewNode
=== PAUSE TestAccResourceFlow_ComputeDifferences_NewNode
=== RUN   TestAccResourceFlow_UnknownFlowString
=== PAUSE TestAccResourceFlow_UnknownFlowString
=== RUN   TestAccResourceFlow_BrokenFlow
=== PAUSE TestAccResourceFlow_BrokenFlow
=== RUN   TestAccResourceFlow_Variables_Clean
=== PAUSE TestAccResourceFlow_Variables_Clean
=== RUN   TestAccResourceFlow_Variables_WithBootstrap
=== PAUSE TestAccResourceFlow_Variables_WithBootstrap
=== RUN   TestAccResourceFlow_Variables_Invalid
=== PAUSE TestAccResourceFlow_Variables_Invalid
=== RUN   TestAccResourceFlow_Variables_Overridden_Clean
=== PAUSE TestAccResourceFlow_Variables_Overridden_Clean
=== RUN   TestAccResourceFlow_Variables_Overridden_WithBootstrap
=== PAUSE TestAccResourceFlow_Variables_Overridden_WithBootstrap
=== RUN   TestAccResourceFlow_BadParameters
=== PAUSE TestAccResourceFlow_BadParameters
=== CONT  TestAccResourceFlow_RemovalDrift
=== CONT  TestAccResourceFlow_ComputeDifferences_AdditionalProperties
=== CONT  TestAccResourceFlow_ComputeDifferences_Description
=== CONT  TestAccResourceFlow_Variables_WithBootstrap
=== CONT  TestAccResourceFlow_Variables_Overridden_WithBootstrap
=== CONT  TestAccResourceFlow_BrokenFlow
=== CONT  TestAccResourceFlow_Variables_Overridden_Clean
=== CONT  TestAccResourceFlow_Variables_Invalid
=== CONT  TestAccResourceFlow_BadParameters
=== CONT  TestAccResourceFlow_UnknownFlowString
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean
=== CONT  TestAccResourceFlow_ComputeDifferences_NewNode
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean
=== NAME  TestAccResourceFlow_Variables_WithBootstrap
    resource_flow_test.go:1001: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap
=== CONT  TestAccResourceFlow_Basic_WithBootstrap
=== CONT  TestAccResourceFlow_Variables_Clean
--- SKIP: TestAccResourceFlow_Variables_WithBootstrap (0.02s)
=== CONT  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
=== NAME  TestAccResourceFlow_Variables_Overridden_WithBootstrap
    resource_flow_test.go:1239: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_Variables_Overridden_WithBootstrap (0.02s)
=== CONT  TestAccResourceFlow_Basic_Clean
=== NAME  TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap
    resource_flow_test.go:323: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_WithBootstrap (0.01s)
=== CONT  TestAccResourceFlow_ComputeDifferences_ModifySettings
=== NAME  TestAccResourceFlow_Basic_WithBootstrap
    resource_flow_test.go:178: Skipping test with bootstrap config: https://github.com/pingidentity/terraform-provider-davinci/issues/266
--- SKIP: TestAccResourceFlow_Basic_WithBootstrap (0.01s)
=== CONT  TestAccResourceFlow_ComputeDifferences_Version
--- PASS: TestAccResourceFlow_Variables_Invalid (35.78s)
=== CONT  TestAccResourceFlow_ComputeDifferences_CompanyId
--- PASS: TestAccResourceFlow_BrokenFlow (199.63s)
--- PASS: TestAccResourceFlow_UnknownFlowString (265.89s)
=== NAME  TestAccResourceFlow_RemovalDrift
    resource_flow_test.go:39: Skipping step 3/4 due to SkipFunc
    resource_flow_test.go:39: Skipping step 4/4 due to SkipFunc
--- PASS: TestAccResourceFlow_RemovalDrift (279.92s)
=== NAME  TestAccResourceFlow_Variables_Clean
    resource_flow_test.go:995: Skipping step 2/4 due to SkipFunc
=== NAME  TestAccResourceFlow_Variables_Overridden_Clean
    resource_flow_test.go:1233: Skipping step 2/4 due to SkipFunc
--- PASS: TestAccResourceFlow_BadParameters (300.76s)
--- PASS: TestAccResourceFlow_ComputeDifferences_AdditionalProperties (313.90s)
--- PASS: TestAccResourceFlow_ComputeDifferences_ModifySettings (314.13s)
--- PASS: TestAccResourceFlow_ComputeDifferences_Version (316.83s)
--- PASS: TestAccResourceFlow_ComputeDifferences_Description (323.53s)
--- PASS: TestAccResourceFlow_ComputeDifferences_CompanyId (294.48s)
--- PASS: TestAccResourceFlow_ComputeDifferences_NewNode (339.25s)
--- PASS: TestAccResourceFlow_Variables_Clean (421.48s)
--- PASS: TestAccResourceFlow_Variables_Overridden_Clean (464.75s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_Clean (573.60s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithMappingIDs_Clean (578.84s)
--- PASS: TestAccResourceFlow_Basic_Clean (594.40s)
--- PASS: TestAccResourceFlow_ConnectionSubflowLinks_WithoutMappingIDs_WithBootstrap (936.92s)
PASS
ok      github.com/pingidentity/terraform-provider-davinci/internal/service/davinci     938.093s
```

</details>