### PR TITLE
Fix value conversion error when using unknown variable values

### DIFF
--- a/.changelog/365.txt
+++ b/.changelog/365.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/davinci_variable`: Fix "Value Conversion Error" when defining variables with unknown values.
+```


### PR DESCRIPTION
### Changes

**BUG FIX** `resource/davinci_variable`: Fix "Value Conversion Error" when defining variables with unknown values.

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccResourceVariable_ github.com/pingidentity/terraform-provider-davinci/internal/service/davinci 
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccResourceVariable_RemovalDrift
=== PAUSE TestAccResourceVariable_RemovalDrift
=== RUN   TestAccResourceVariable_Full_CompanyContext_Clean
=== PAUSE TestAccResourceVariable_Full_CompanyContext_Clean
=== RUN   TestAccResourceVariable_Full_CompanyContext_WithBootstrap
=== PAUSE TestAccResourceVariable_Full_CompanyContext_WithBootstrap
=== RUN   TestAccResourceVariable_Full_FlowInstanceContext_Clean
=== PAUSE TestAccResourceVariable_Full_FlowInstanceContext_Clean
=== RUN   TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
=== PAUSE TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
=== RUN   TestAccResourceVariable_Full_UserContext_Clean
=== PAUSE TestAccResourceVariable_Full_UserContext_Clean
=== RUN   TestAccResourceVariable_Full_UserContext_WithBootstrap
=== PAUSE TestAccResourceVariable_Full_UserContext_WithBootstrap
=== RUN   TestAccResourceVariable_ChangeDataType
=== PAUSE TestAccResourceVariable_ChangeDataType
=== RUN   TestAccResourceVariable_Values_CompanyContext
=== PAUSE TestAccResourceVariable_Values_CompanyContext
=== RUN   TestAccResourceVariable_Values_FlowInstanceContext
=== PAUSE TestAccResourceVariable_Values_FlowInstanceContext
=== RUN   TestAccResourceVariable_Values_FlowContext
=== PAUSE TestAccResourceVariable_Values_FlowContext
=== RUN   TestAccResourceVariable_UnknownValue
=== PAUSE TestAccResourceVariable_UnknownValue
=== RUN   TestAccResourceVariable_BadParameters
=== PAUSE TestAccResourceVariable_BadParameters
=== CONT  TestAccResourceVariable_RemovalDrift
=== CONT  TestAccResourceVariable_ChangeDataType
=== CONT  TestAccResourceVariable_Values_FlowContext
=== CONT  TestAccResourceVariable_BadParameters
=== CONT  TestAccResourceVariable_UnknownValue
=== CONT  TestAccResourceVariable_Values_FlowInstanceContext
=== CONT  TestAccResourceVariable_Values_CompanyContext
=== CONT  TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
=== CONT  TestAccResourceVariable_Full_CompanyContext_WithBootstrap
=== CONT  TestAccResourceVariable_Full_CompanyContext_Clean
=== CONT  TestAccResourceVariable_Full_UserContext_WithBootstrap
=== CONT  TestAccResourceVariable_Full_UserContext_Clean
=== CONT  TestAccResourceVariable_Full_FlowInstanceContext_Clean
=== NAME  TestAccResourceVariable_RemovalDrift
    resource_variable_test.go:33: Skipping step 3/4 due to SkipFunc
    resource_variable_test.go:33: Skipping step 4/4 due to SkipFunc
--- PASS: TestAccResourceVariable_RemovalDrift (129.84s)
--- PASS: TestAccResourceVariable_BadParameters (135.44s)
--- PASS: TestAccResourceVariable_ChangeDataType (219.55s)
=== NAME  TestAccResourceVariable_Full_UserContext_Clean
    resource_variable_test.go:392: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
    resource_variable_test.go:288: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_UserContext_WithBootstrap
    resource_variable_test.go:392: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_CompanyContext_WithBootstrap
    resource_variable_test.go:164: Skipping step 6/12 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_FlowInstanceContext_Clean
    resource_variable_test.go:288: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_CompanyContext_Clean
    resource_variable_test.go:164: Skipping step 6/12 due to SkipFunc
--- PASS: TestAccResourceVariable_UnknownValue (314.95s)
--- PASS: TestAccResourceVariable_Full_FlowInstanceContext_Clean (361.64s)
--- PASS: TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap (366.94s)
--- PASS: TestAccResourceVariable_Full_UserContext_Clean (367.39s)
--- PASS: TestAccResourceVariable_Full_UserContext_WithBootstrap (369.29s)
--- PASS: TestAccResourceVariable_Full_CompanyContext_Clean (435.50s)
--- PASS: TestAccResourceVariable_Full_CompanyContext_WithBootstrap (436.38s)
--- PASS: TestAccResourceVariable_Values_CompanyContext (480.72s)
--- PASS: TestAccResourceVariable_Values_FlowInstanceContext (482.03s)
--- PASS: TestAccResourceVariable_Values_FlowContext (488.49s)
PASS
ok      github.com/pingidentity/terraform-provider-davinci/internal/service/davinci     489.415s
```

</details>