### PR TITLE
Fix gosec errors

### DIFF
--- a/dvgenerate/generate.go
+++ b/dvgenerate/generate.go
@@ -105,6 +105,7 @@ func writeTemplateFile(t *template.Template, fileName string, overwrite bool, da
 		return fmt.Errorf("failed to check if file exists: %v", err)
 	}
 
+	fileName = filepath.Clean(fileName)
 	outputFile, err := os.Create(fileName)
 	if err != nil {
 		return err

--- a/internal/service/davinci/resource_variable.go
+++ b/internal/service/davinci/resource_variable.go
@@ -754,20 +754,30 @@ func (p *VariableResourceModel) toState(apiObject map[string]davinci.Variable) d
 			}
 			value = string(bytes)
 		}
-		
+
 		p.ValueService = framework.StringToTF(value)
 	} else {
 		p.ValueService = types.StringNull()
 	}
 
 	if v := variableObject.Min; v != nil {
-		p.Min = framework.Int32ToTF(int32(*v))
+		safeInt, err := utils.SafeIntToInt32(*v)
+		if err != nil {
+			diags.AddError("Error converting min value", err.Error())
+		} else {
+			p.Min = framework.Int32ToTF(safeInt)
+		}
 	} else {
 		p.Min = types.Int64Null()
 	}
 
 	if v := variableObject.Max; v != nil {
-		p.Max = framework.Int32ToTF(int32(*v))
+		safeInt, err := utils.SafeIntToInt32(*v)
+		if err != nil {
+			diags.AddError("Error converting max value", err.Error())
+		} else {
+			p.Max = framework.Int32ToTF(safeInt)
+		}
 	} else {
 		p.Max = types.Int64Null()
 	}

--- a/internal/utils/int.go
+++ b/internal/utils/int.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"errors"
+	"math"
+)
+
+func SafeIntToInt32(value int) (int32, error) {
+	if value > math.MaxInt32 || value < math.MinInt32 {
+		return 0, errors.New("value out of range for int32")
+	}
+	return int32(value), nil
+}


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

Fix gosec code errors.  No functional change, no changelog necessary.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-davinci/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccResourceVariable_Full_CompanyContext_Clean github.com/pingidentity/terraform-provider-davinci/internal/service/davinci
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccResourceVariable_Full_CompanyContext_Clean
=== PAUSE TestAccResourceVariable_Full_CompanyContext_Clean
=== CONT  TestAccResourceVariable_Full_CompanyContext_Clean
    resource_variable_test.go:164: Skipping step 6/12 due to SkipFunc
--- PASS: TestAccResourceVariable_Full_CompanyContext_Clean (284.51s)
PASS
ok      github.com/pingidentity/terraform-provider-davinci/internal/service/davinci     285.298s
```

</details>
