### PR TITLE
Fix "Provider produced inconsistent result after apply" when the settings.logLevel value is re-defined by the DaVinci service

### DIFF
--- a/.changelog/462.txt
+++ b/.changelog/462.txt
@@ -1,0 +1,7 @@
+```release-note:note
+bump `github.com/samir-gandhi/davinci-client-go` 0.8.0 => 0.9.0
+```
+
+```release-note:bug
+`resource/davinci_flow`: Fix "Provider produced inconsistent result after apply" when the `settings.logLevel` value is re-defined by the DaVinci service.
+```

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/pingidentity/terraform-provider-davinci
 
 go 1.24.1
 
+replace github.com/samir-gandhi/davinci-client-go => github.com/samir-gandhi/davinci-client-go v0.8.1-0.20250402153206-248ddafd75fa
+
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/pingidentity/terraform-provider-davinci
 
 go 1.24.1
 
-replace github.com/samir-gandhi/davinci-client-go => github.com/samir-gandhi/davinci-client-go v0.8.1-0.20250402153206-248ddafd75fa
-
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -15,7 +13,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/patrickcping/pingone-go-sdk-v2 v0.12.13
 	github.com/patrickcping/pingone-go-sdk-v2/management v0.53.0
-	github.com/samir-gandhi/davinci-client-go v0.8.0
+	github.com/samir-gandhi/davinci-client-go v0.9.0
 )
 
 require (
@@ -24,7 +22,7 @@ require (
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.23.0 // indirect
+	github.com/go-playground/validator/v10 v10.26.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.0 // indirect
 	github.com/patrickcping/pingone-go-sdk-v2/credentials v0.11.0 // indirect
@@ -44,7 +42,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-test/deep v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FM
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
-github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
+github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
+github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.6.0 h1:w2hPNtoehvJIxR00Vb4xX94qHQi/ApZfX+nBE2Cjio8=
@@ -43,8 +43,8 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.23.0 h1:/PwmTwZhS0dPkav3cdK9kV1FsAmrL8sThn8IHr/sO+o=
-github.com/go-playground/validator/v10 v10.23.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/go-playground/validator/v10 v10.26.0 h1:SP05Nqhjcvz81uJaRfEV0YBSSSGMc/iMaVtFbr3Sw2k=
+github.com/go-playground/validator/v10 v10.26.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
@@ -170,8 +170,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
-github.com/samir-gandhi/davinci-client-go v0.8.1-0.20250402153206-248ddafd75fa h1:U7pkKz8mFxD+dxh4fhvCw8aEsqIhaFiMuaG0pOAQlzE=
-github.com/samir-gandhi/davinci-client-go v0.8.1-0.20250402153206-248ddafd75fa/go.mod h1:0CxhVhW9epuDN4b7mq1Hgbhmti8HBBlfOnE5bF1derE=
+github.com/samir-gandhi/davinci-client-go v0.9.0 h1:TF5W8Ui8/dolT4Kkcb6PyvAGp5Zqu+xCwezxLd6AG8M=
+github.com/samir-gandhi/davinci-client-go v0.9.0/go.mod h1:wVHrd8SCO2Sl0K5AsI3NkiW7ftq7fVWP80uRRJ50WY4=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0LY=

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
-github.com/samir-gandhi/davinci-client-go v0.8.0 h1:YJmDQIecVu7MZYFW4/QgQqUVymnc6l7HTM2/XEli0Ik=
-github.com/samir-gandhi/davinci-client-go v0.8.0/go.mod h1:0CxhVhW9epuDN4b7mq1Hgbhmti8HBBlfOnE5bF1derE=
+github.com/samir-gandhi/davinci-client-go v0.8.1-0.20250402153206-248ddafd75fa h1:U7pkKz8mFxD+dxh4fhvCw8aEsqIhaFiMuaG0pOAQlzE=
+github.com/samir-gandhi/davinci-client-go v0.8.1-0.20250402153206-248ddafd75fa/go.mod h1:0CxhVhW9epuDN4b7mq1Hgbhmti8HBBlfOnE5bF1derE=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0LY=

--- a/internal/service/davinci/resource_flow_test.go
+++ b/internal/service/davinci/resource_flow_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/pingidentity/terraform-provider-davinci/internal/acctest"
 	"github.com/pingidentity/terraform-provider-davinci/internal/acctest/service/davinci"
+	"github.com/pingidentity/terraform-provider-davinci/internal/utils"
 	"github.com/pingidentity/terraform-provider-davinci/internal/verify"
 	dv "github.com/samir-gandhi/davinci-client-go/davinci"
 )
@@ -519,11 +520,11 @@ func TestAccResourceFlow_ComputeDifferences_ModifySettings(t *testing.T) {
 		BaselineFlow: flow,
 		ModifiedFlow: func() dv.Flow {
 			newFlow := flow
-			newFlow.Settings = map[string]interface{}{
-				"csp":                           "worker-src 'self' blob:; script-src 'self' https://cdn.jsdelivr.net https://code.jquery.com https://devsdk.singularkey.com http://cdnjs.cloudflare.com 'unsafe-inline' 'unsafe-eval';",
-				"intermediateLoadingScreenCSS":  "",
-				"intermediateLoadingScreenHTML": "",
-				"flowHttpTimeoutInSeconds":      301,
+			newFlow.Settings = &dv.FlowSettings{
+				Csp:                           utils.StringPtr("worker-src 'self' blob:; script-src 'self' https://cdn.jsdelivr.net https://code.jquery.com https://devsdk.singularkey.com http://cdnjs.cloudflare.com 'unsafe-inline' 'unsafe-eval';"),
+				IntermediateLoadingScreenCSS:  utils.StringPtr(""),
+				IntermediateLoadingScreenHTML: utils.StringPtr(""),
+				FlowHttpTimeoutInSeconds:      utils.Int32Ptr(301),
 			}
 
 			return newFlow

--- a/internal/utils/int.go
+++ b/internal/utils/int.go
@@ -11,3 +11,7 @@ func SafeIntToInt32(value int) (int32, error) {
 	}
 	return int32(value), nil
 }
+
+func Int32Ptr(d int32) *int32 {
+	return &d
+}

--- a/internal/utils/string.go
+++ b/internal/utils/string.go
@@ -31,3 +31,7 @@ func StringSliceToAnySlice(v []string) []any {
 	}
 	return result
 }
+
+func StringPtr(s string) *string {
+    return &s
+}


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- bump `github.com/samir-gandhi/davinci-client-go` 0.8.0 => 0.9.0
- `resource/davinci_flow`: Fix "Provider produced inconsistent result after apply" when the `settings.logLevel` value is re-defined by the DaVinci service.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing

Deferred to GH actions workflow