### PR TITLE
Correct error handling for variables

### DIFF
--- a/.changelog/467.txt
+++ b/.changelog/467.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/davinci_variable`: Fix "Error creating variable: [variable name]. Construct already exists" error when defining flow context variables that have been implicitly created by flow import.
+```

--- a/go.work.sum
+++ b/go.work.sum
@@ -636,6 +636,7 @@ gocloud.dev v0.40.0 h1:f8LgP+4WDqOG/RXoUcyLpeIAGOcAbZrZbDQCUee10ng=
 gocloud.dev v0.40.0/go.mod h1:drz+VyYNBvrMTW0KZiBAYEdl8lbNZx+OQ7oQvdrFmSQ=
 golang.org/x/arch v0.1.0 h1:oMxhUYsO9VsR1dcoVUjJjIGhx1LXol3989T/yZ59Xsw=
 golang.org/x/crypto v0.29.0/go.mod h1:+F4F4N5hv6v38hfeYwTdx20oUvLLc+QfrE9Ax9HtgRg=
+golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 golang.org/x/image v0.0.0-20220302094943-723b81ca9867 h1:TcHcE0vrmgzNH1v3ppjcMGbhG5+9fMuvOmUYwNEF4q4=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 h1:4+4C/Iv2U4fMZBiMCc98MG1In4gJY5YRhtpDNeDeHWs=

--- a/go.work.sum
+++ b/go.work.sum
@@ -643,6 +643,7 @@ golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 h1:4+4C/Iv2U4fMZBiMCc98MG
 golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.22.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/oauth2 v0.25.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/service/davinci/resource_variable.go
+++ b/internal/service/davinci/resource_variable.go
@@ -364,7 +364,7 @@ func (r *VariableResource) Create(ctx context.Context, req resource.CreateReques
 		},
 	)
 	if err != nil {
-		if strings.Contains(err.Error(), "Record already exists") {
+		if strings.Contains(err.Error(), "already exists") {
 			if plan.Context.ValueString() == contextFlow {
 				// we override "flow" variables
 				response, err = sdk.DoRetryable(
@@ -571,7 +571,7 @@ func (r *VariableResource) Delete(ctx context.Context, req resource.DeleteReques
 	)
 
 	if err != nil {
-		if strings.Contains(err.Error(), "Variable not found") {
+		if strings.Contains(err.Error(), "not found") {
 			return
 		}
 

--- a/internal/service/davinci/resource_variable.go
+++ b/internal/service/davinci/resource_variable.go
@@ -364,7 +364,7 @@ func (r *VariableResource) Create(ctx context.Context, req resource.CreateReques
 		},
 	)
 	if err != nil {
-		if strings.Contains(err.Error(), "already exists") {
+		if strings.Contains(strings.ToLower(err.Error()), strings.ToLower("already exists")) {
 			if plan.Context.ValueString() == contextFlow {
 				// we override "flow" variables
 				response, err = sdk.DoRetryable(
@@ -571,7 +571,7 @@ func (r *VariableResource) Delete(ctx context.Context, req resource.DeleteReques
 	)
 
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if strings.Contains(strings.ToLower(err.Error()), strings.ToLower("not found")) {
 			return
 		}
 


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- Bug: `resource/davinci_variable`: Fix "Error creating variable: [variable name]. Construct already exists" error when defining flow context variables that have been implicitly created by flow import.
 
### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-davinci/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccResourceVariable_ github.com/pingidentity/terraform-provider-davinci/internal/service/davinci
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccResourceVariable_RemovalDrift
=== PAUSE TestAccResourceVariable_RemovalDrift
=== RUN   TestAccResourceVariable_Full_CompanyContext_Clean
=== PAUSE TestAccResourceVariable_Full_CompanyContext_Clean
=== RUN   TestAccResourceVariable_Full_CompanyContext_WithBootstrap
=== PAUSE TestAccResourceVariable_Full_CompanyContext_WithBootstrap
=== RUN   TestAccResourceVariable_Full_FlowInstanceContext_Clean
=== PAUSE TestAccResourceVariable_Full_FlowInstanceContext_Clean
=== RUN   TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
=== PAUSE TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
=== RUN   TestAccResourceVariable_Full_UserContext_Clean
=== PAUSE TestAccResourceVariable_Full_UserContext_Clean
=== RUN   TestAccResourceVariable_Full_UserContext_WithBootstrap
=== PAUSE TestAccResourceVariable_Full_UserContext_WithBootstrap
=== RUN   TestAccResourceVariable_ChangeDataType
=== PAUSE TestAccResourceVariable_ChangeDataType
=== RUN   TestAccResourceVariable_Values_CompanyContext
=== PAUSE TestAccResourceVariable_Values_CompanyContext
=== RUN   TestAccResourceVariable_Values_FlowInstanceContext
=== PAUSE TestAccResourceVariable_Values_FlowInstanceContext
=== RUN   TestAccResourceVariable_Values_FlowContext
=== PAUSE TestAccResourceVariable_Values_FlowContext
=== RUN   TestAccResourceVariable_UnknownValue
=== PAUSE TestAccResourceVariable_UnknownValue
=== RUN   TestAccResourceVariable_BadParameters
=== PAUSE TestAccResourceVariable_BadParameters
=== CONT  TestAccResourceVariable_RemovalDrift
=== CONT  TestAccResourceVariable_ChangeDataType
=== CONT  TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
=== CONT  TestAccResourceVariable_Full_FlowInstanceContext_Clean
=== CONT  TestAccResourceVariable_UnknownValue
=== CONT  TestAccResourceVariable_Values_FlowInstanceContext
=== CONT  TestAccResourceVariable_Values_CompanyContext
=== CONT  TestAccResourceVariable_Full_UserContext_WithBootstrap
=== CONT  TestAccResourceVariable_Full_CompanyContext_Clean
=== CONT  TestAccResourceVariable_Full_UserContext_Clean
=== CONT  TestAccResourceVariable_Full_CompanyContext_WithBootstrap
=== CONT  TestAccResourceVariable_BadParameters
=== CONT  TestAccResourceVariable_Values_FlowContext
=== NAME  TestAccResourceVariable_RemovalDrift
    resource_variable_test.go:33: Skipping step 3/4 due to SkipFunc
    resource_variable_test.go:33: Skipping step 4/4 due to SkipFunc
--- PASS: TestAccResourceVariable_RemovalDrift (117.08s)
--- PASS: TestAccResourceVariable_BadParameters (156.92s)
--- PASS: TestAccResourceVariable_ChangeDataType (184.67s)
=== NAME  TestAccResourceVariable_Full_CompanyContext_Clean
    resource_variable_test.go:164: Skipping step 6/12 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_FlowInstanceContext_Clean
    resource_variable_test.go:288: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_CompanyContext_WithBootstrap
    resource_variable_test.go:164: Skipping step 6/12 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap
    resource_variable_test.go:288: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_UserContext_Clean
    resource_variable_test.go:392: Skipping step 6/8 due to SkipFunc
=== NAME  TestAccResourceVariable_Full_UserContext_WithBootstrap
    resource_variable_test.go:392: Skipping step 6/8 due to SkipFunc
--- PASS: TestAccResourceVariable_UnknownValue (248.64s)
--- PASS: TestAccResourceVariable_Full_UserContext_Clean (272.24s)
--- PASS: TestAccResourceVariable_Full_FlowInstanceContext_WithBootstrap (274.13s)
--- PASS: TestAccResourceVariable_Full_FlowInstanceContext_Clean (274.28s)
--- PASS: TestAccResourceVariable_Full_UserContext_WithBootstrap (274.99s)
--- PASS: TestAccResourceVariable_Full_CompanyContext_WithBootstrap (335.64s)
--- PASS: TestAccResourceVariable_Full_CompanyContext_Clean (336.31s)
--- PASS: TestAccResourceVariable_Values_FlowInstanceContext (389.89s)
--- PASS: TestAccResourceVariable_Values_CompanyContext (392.22s)
--- PASS: TestAccResourceVariable_Values_FlowContext (392.24s)
PASS
ok      github.com/pingidentity/terraform-provider-davinci/internal/service/davinci     394.068s
```

</details>
