### PR TITLE
Correct implicit variable management when performing flow updates

### DIFF
--- a/internal/service/davinci/resource_flow.go
+++ b/internal/service/davinci/resource_flow.go
@@ -843,8 +843,8 @@ func (r *FlowResource) Update(ctx context.Context, req resource.UpdateRequest, r
 						},
 					)
 					if err != nil {
-						// if error starts with "Record already exists" then ignore it
-						if !strings.HasPrefix(err.Error(), "Record already exists") {
+						// if error contains "already exists" then ignore it
+						if !strings.Contains(strings.ToLower(err.Error()), "already exists") {
 							resp.Diagnostics.AddError(
 								fmt.Sprintf("Error adding %s variable", flowVariable.Context),
 								fmt.Sprintf("Error adding %s variable %s as part of flow update: %s", flowVariable.Context, *flowVariable.Name, err),
@@ -874,7 +874,7 @@ func (r *FlowResource) Update(ctx context.Context, req resource.UpdateRequest, r
 						},
 					)
 					if err != nil {
-						if !strings.HasPrefix(err.Error(), "Error deleting record") {
+						if !strings.Contains(strings.ToLower(err.Error()), "not found") {
 							resp.Diagnostics.AddError(
 								fmt.Sprintf("Error removing %s variable", flowVar.Context.ValueString()),
 								fmt.Sprintf("Error removing %s variable %s as part of flow update: %s", flowVar.Context.ValueString(), flowVar.Name.ValueString(), err),


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

Closes #471 and #470 

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-davinci/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccResourceFlow_Variables_ github.com/pingidentity/terraform-provider-davinci/internal/service/davinci
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell

```

</details>
