### PR TITLE
CDI-904 support trigger attributes davinci application flow policy

### DIFF
--- a/.changelog/610.txt
+++ b/.changelog/610.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+`resource/davinci_application_flow_policy`: Added `trigger` block supporting PingOne flow policy trigger configuration, including `trigger.configuration.mfa` and `trigger.configuration.pwd` sub-blocks. The `trigger.type` attribute is computed from the DaVinci API.
+```
+
+```release-note:note
+bump `github.com/samir-gandhi/davinci-client-go` 0.12.0 => 0.13.0
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.6.0 (20 April 2026)
+
+NOTES:
+
+* bump `github.com/samir-gandhi/davinci-client-go` 0.12.0 => 0.13.0 ([#610](https://github.com/pingidentity/terraform-provider-davinci/issues/610))
+
+ENHANCEMENTS:
+
+* `resource/davinci_application_flow_policy`: Added `trigger` block supporting PingOne flow policy trigger configuration, including `trigger.configuration.mfa` and `trigger.configuration.pwd` sub-blocks. The `trigger.type` attribute is computed from the DaVinci API. ([#610](https://github.com/pingidentity/terraform-provider-davinci/issues/610))
+
 ## 0.5.5 (20 April 2026)
 
 NOTES:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,7 +4,7 @@ DAVINCI_DIR=./internal/service/davinci
 NAMESPACE=pingidentity
 PKG_NAME=davinci
 BINARY=terraform-provider-${NAME}
-VERSION=0.5.5
+VERSION=0.6.0
 OS_ARCH=linux_amd64
 
 default: install

--- a/docs/resources/application_flow_policy.md
+++ b/docs/resources/application_flow_policy.md
@@ -59,6 +59,7 @@ resource "davinci_application_flow_policy" "my_awesome_registration_flow_applica
 ### Optional
 
 - `status` (String) A boolan that specifies whether the policy should be enabled. Valid values are: `enabled`, `disabled`. Defaults to `enabled`.
+- `trigger` (Block List, Max: 1) A block that specifies the trigger configuration for PingOne flow policies. (see [below for nested schema](#nestedblock--trigger))
 
 ### Read-Only
 
@@ -78,6 +79,45 @@ Optional:
 - `allowed_ip_list` (Set of String) A list of IP CIDR entries that are allowed use of the application policy flow.
 - `success_nodes` (Set of String) A list of node ids used by analytics for tracking user interaction.
 - `weight` (Number) If multiple flows are specified, the weight determines the probability of the flow being used. The weights across all policy flows must add up to `100`.
+
+
+<a id="nestedblock--trigger"></a>
+### Nested Schema for `trigger`
+
+Optional:
+
+- `configuration` (Block List, Max: 1) A block that specifies the trigger configuration details. (see [below for nested schema](#nestedblock--trigger--configuration))
+
+Read-Only:
+
+- `type` (String) A string that specifies the trigger type. Set by the DaVinci API.
+
+<a id="nestedblock--trigger--configuration"></a>
+### Nested Schema for `trigger.configuration`
+
+Optional:
+
+- `mfa` (Block List, Max: 1) A block that specifies the MFA trigger configuration. (see [below for nested schema](#nestedblock--trigger--configuration--mfa))
+- `pwd` (Block List, Max: 1) A block that specifies the password trigger configuration. (see [below for nested schema](#nestedblock--trigger--configuration--pwd))
+
+<a id="nestedblock--trigger--configuration--mfa"></a>
+### Nested Schema for `trigger.configuration.mfa`
+
+Optional:
+
+- `enabled` (Boolean) A boolean that specifies whether MFA trigger is enabled.
+- `time` (Number) A number that specifies the MFA trigger time.
+- `time_format` (String) A string that specifies the MFA trigger time format. Valid values are `min`, `hour`, `day`.
+
+
+<a id="nestedblock--trigger--configuration--pwd"></a>
+### Nested Schema for `trigger.configuration.pwd`
+
+Optional:
+
+- `enabled` (Boolean) A boolean that specifies whether password trigger is enabled.
+- `time` (Number) A number that specifies the password trigger time.
+- `time_format` (String) A string that specifies the password trigger time format. Valid values are `min`, `hour`, `day`.
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0
 	github.com/patrickcping/pingone-go-sdk-v2 v0.14.13
 	github.com/patrickcping/pingone-go-sdk-v2/management v0.69.0
-	github.com/samir-gandhi/davinci-client-go v0.12.0
+	github.com/samir-gandhi/davinci-client-go v0.13.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/samir-gandhi/davinci-client-go v0.12.0 h1:fD1UEw5HKt21RXhRmhVAKskwK04RJSPpY7kltUP8VpQ=
-github.com/samir-gandhi/davinci-client-go v0.12.0/go.mod h1:/12KKDJyNUxSUQEaF1EHCJx/PD7nHTBEGsuGNXjpPsU=
+github.com/samir-gandhi/davinci-client-go v0.13.0 h1:WvRPhrp/EwLavgmmvXG+Z0Wl8Ao2qHlDd7pnw5jWLZw=
+github.com/samir-gandhi/davinci-client-go v0.13.0/go.mod h1:/12KKDJyNUxSUQEaF1EHCJx/PD7nHTBEGsuGNXjpPsU=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=

--- a/go.work.sum
+++ b/go.work.sum
@@ -113,6 +113,7 @@ cloud.google.com/go/gkeconnect v0.12.5/go.mod h1:wMD2RXcsAWlkREZWJDVeDV70PYka1iE
 cloud.google.com/go/gkehub v0.16.0/go.mod h1:ADp27Ucor8v81wY+x/5pOxTorxkPj/xswH3AUpN62GU=
 cloud.google.com/go/gkemulticloud v1.5.4/go.mod h1:7l9+6Tp4jySSGj4PStO8CE6RrHFdcRARK4ScReHX1bU=
 cloud.google.com/go/gkemulticloud v1.6.0/go.mod h1:bGpd4o/Z5Z/XFlaojkgdVisHRwb+fLJvUPzsmV0I9ok=
+cloud.google.com/go/grafeas v0.3.16/go.mod h1:I/yrRMOEsLasrmZXQzmDXwrJ3ZPn3dQWLaWt4lXmYvE=
 cloud.google.com/go/gsuiteaddons v1.7.8/go.mod h1:DBKNHH4YXAdd/rd6zVvtOGAJNGo0ekOh+nIjTUDEJ5U=
 cloud.google.com/go/iam v1.5.2/go.mod h1:SE1vg0N81zQqLzQEwxL2WI6yhetBdbNQuTvIKCSkUHE=
 cloud.google.com/go/iap v1.11.3/go.mod h1:+gXO0ClH62k2LVlfhHzrpiHQNyINlEVmGAE3+DB4ShU=
@@ -207,12 +208,14 @@ codeberg.org/go-fonts/liberation v0.5.0/go.mod h1:zS/2e1354/mJ4pGzIIaEtm/59VFCFn
 codeberg.org/go-latex/latex v0.1.0/go.mod h1:LA0q/AyWIYrqVd+A9Upkgsb+IqPcmSTKc9Dny04MHMw=
 codeberg.org/go-pdf/fpdf v0.10.0/go.mod h1:Y0DGRAdZ0OmnZPvjbMp/1bYxmIPxm0ws4tfoPOc4LjU=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.14/go.mod h1:5pSSGY0Bhuk7waTHuDf4aQ8D2DrhgETRo9fy6k3Xlzc=
+contrib.go.opencensus.io/exporter/stackdriver v0.13.15-0.20230702191903-2de6d2748484/go.mod h1:uxw+4/0SiKbbVSD/F2tk5pJTdVcfIBBcsQ8gwcu4X+E=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 git.sr.ht/~sbinet/gg v0.6.0/go.mod h1:uucygbfC9wVPQIfrmwM2et0imr8L7KQWywX0xpFMm94=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3/go.mod h1:dppbR7CwXD4pgtV9t3wD1812RaLDcBjtblcDF5f1vI0=
+github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.6.0/go.mod h1:I7kE2kM3qCr9QPT4cU4cCFYkEpVyVr16YOGUHzy+nR0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0/go.mod h1:yAZHSGnqScoU556rBOVkwLze6WP5N+U11RHuWaGVxwY=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 h1:DHa2U07rk8syqvCge0QIGMCE1WxGj9njT44GH7zNJLQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
@@ -231,6 +234,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b/go.mod h1:fvzegU4vN3H1qMT+8wDmzjAcDONcgo2/SZ/TyfdUOFs=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/apache/arrow/go/v15 v15.0.2/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
 github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
@@ -248,6 +252,7 @@ github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.16/go.mod
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.20/go.mod h1:ihZMtPTKoX/ugQRHbui6zNdSgVYN1KY2Dgwb2d3hXlc=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.20/go.mod h1:V4X406Y666khGa8ghKmphma/7C0DAtEQYhkq9z4vpbk=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.20/go.mod h1:4TLZCmVJDM3FOu5P5TJP0zOlu9zWgDWU7aUxWbr+rcw=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.62.3/go.mod h1:DHddp7OO4bY467WVCqWBzk5+aEWn7vqYkap7UigJzGk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1/go.mod h1:qXVal5H0ChqXP63t6jze5LmFalc7+ZE7wOdLtZ0LCP0=
 github.com/aws/aws-sdk-go-v2/service/sns v1.39.8/go.mod h1:3aOzyhwa/mXPZYLwGaALfl88GFRXHQKXdyQSq2L/Y4g=
 github.com/aws/aws-sdk-go-v2/service/sns v1.39.13/go.mod h1:RwF6Xnba8PlINxJUQq1IAWeon6IglvqsnhNqV8QsQjk=
@@ -335,6 +340,8 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/go-redis/redismock/v9 v9.2.0/go.mod h1:18KHfGDK4Y6c2R0H38EUGWAdc7ZQS9gfYxc94k7rWT0=
 github.com/go-rod/rod v0.116.2/go.mod h1:H+CMO9SCNc2TJ2WfrG+pKhITz57uGNYU43qYHh438Mg=
 github.com/goccmack/gocc v0.0.0-20230228185258-2292f9e40198/go.mod h1:DTh/Y2+NbnOVVoypCCQrovMPDKUGp4yZpSbWg5D0XIM=
+github.com/goccmack/gocc v1.0.2/go.mod h1:LXX2tFVUggS/Zgx/ICPOr3MLyusuM7EcbfkPvNsjdO8=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
@@ -361,6 +368,7 @@ github.com/google/addlicense v1.1.1/go.mod h1:Sm/DHu7Jk+T5miFHHehdIjbi4M5+dJDRS3
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
+github.com/google/flatbuffers v23.5.26+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -385,6 +393,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/rpmpack v0.7.1/go.mod h1:h1JL16sUTWCLI/c39ox1rDaTBo3BXUQGjczVJyK4toU=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.6.0/go.mod h1:F4QhpQ9EDIdJ1Mbop/NZBRB+5yrR6qg3BnctaoUk6NA=
+github.com/googleapis/cloud-bigtable-clients-test v0.0.4/go.mod h1:NNHPqSxC2OBSLmt1j/qofCRRzL0OYZxk24CsicIe8MA=
 github.com/googleapis/enterprise-certificate-proxy v0.3.6/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/enterprise-certificate-proxy v0.3.7/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/enterprise-certificate-proxy v0.3.11/go.mod h1:RFV7MUdlb7AgEq2v7FmMCfeSMCllAzWxFgRdusoGks8=
@@ -422,6 +431,7 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
@@ -465,6 +475,7 @@ github.com/owenrumney/go-sarif v1.1.1 h1:QNObu6YX1igyFKhdzd7vgzmw7XsWN3/6NMGuDzB
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
+github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -490,6 +501,7 @@ github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE
 github.com/spf13/afero v1.10.0/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GBUCwT2wPmb7g=
+github.com/stoewer/go-strcase v1.3.1/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/terraform-linters/tflint v0.62.0 h1:TbqFWuma66JtWD9Y2yTke2Fq8LVLolA3GJ+/Cn2NGlo=
@@ -532,6 +544,7 @@ github.com/zclconf/go-cty v1.18.0 h1:pJ8+HNI4gFoyRNqVE37wWbJWVw43BZczFo7KUoRczaA
 github.com/zclconf/go-cty v1.18.0/go.mod h1:qpnV6EDNgC1sns/AleL1fvatHw72j+S+nS+MJ+T2CSg=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.einride.tech/aip v0.73.0/go.mod h1:Mj7rFbmXEgw0dq1dqJ7JGMvYCZZVxmGOR3S4ZcV5LvQ=
 go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
 go.etcd.io/etcd/api/v3 v3.6.0/go.mod h1:Wt5yZqEmxgTNJGHob7mTVBJDZNXiHPtXTcPab37iFOw=
@@ -812,8 +825,10 @@ golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg
 golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg=
 golang.org/x/vuln v1.1.4/go.mod h1:F+45wmU18ym/ca5PLTPLsSzr2KppzswxPP603ldA67s=
 golang.org/x/xerrors v0.0.0-20240716161551-93cc26a95ae9/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
+golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 gonum.org/v1/plot v0.15.2/go.mod h1:DX+x+DWso3LTha+AdkJEv5Txvi+Tql3KAGkehP0/Ubg=
+gonum.org/v1/tools v0.0.0-20200318103217-c168b003ce8c/go.mod h1:fy6Otjqbk477ELp8IXTpw1cObQtLbRCBVonY+bTTfcM=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
@@ -937,6 +952,9 @@ google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhH
 google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
 google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
 google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6/go.mod h1:6ytKWczdvnpnO+m+JiG9NjEDzR1FJfsnmJdG7B8QVZ8=
+google.golang.org/grpc/gcp/observability v1.0.1/go.mod h1:yM0UcrYRMe/B+Nu0mDXeTJNDyIMJRJnzuxqnJMz7Ewk=
+google.golang.org/grpc/security/advancedtls v1.0.0/go.mod h1:o+s4go+e1PJ2AjuQMY5hU82W7lDlefjJA6FqEHRVHWk=
+google.golang.org/grpc/stats/opencensus v1.0.0/go.mod h1:FhdkeYvN43wLYUnapVuRJJ9JXkNwe403iLUW2LKSnjs=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
@@ -954,6 +972,7 @@ gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/src-d/go-billy.v4 v4.3.2/go.mod h1:nDjArDMp+XMs1aFAESLRjfGSgfvoYN0hDfzEk0GjC98=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
+gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/service/davinci/resource_application_flow_policy.go
+++ b/internal/service/davinci/resource_application_flow_policy.go
@@ -83,6 +83,7 @@ func ResourceApplicationFlowPolicy() *schema.Resource {
 			"trigger": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				MaxItems:    1,
 				Description: "A block that specifies the trigger configuration for PingOne flow policies.",
 				Elem: &schema.Resource{

--- a/internal/service/davinci/resource_application_flow_policy.go
+++ b/internal/service/davinci/resource_application_flow_policy.go
@@ -80,6 +80,83 @@ func ResourceApplicationFlowPolicy() *schema.Resource {
 					},
 				},
 			},
+			"trigger": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "A block that specifies the trigger configuration for PingOne flow policies.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A string that specifies the trigger type. Set by the DaVinci API.",
+						},
+						"configuration": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							MaxItems:    1,
+							Description: "A block that specifies the trigger configuration details.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"mfa": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										MaxItems:    1,
+										Description: "A block that specifies the MFA trigger configuration.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enabled": {
+													Type:        schema.TypeBool,
+													Optional:    true,
+													Description: "A boolean that specifies whether MFA trigger is enabled.",
+												},
+												"time": {
+													Type:        schema.TypeFloat,
+													Optional:    true,
+													Description: "A number that specifies the MFA trigger time.",
+												},
+												"time_format": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													Description:      "A string that specifies the MFA trigger time format. Valid values are `min`, `hour`, `day`.",
+													ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"min", "hour", "day"}, false)),
+												},
+											},
+										},
+									},
+									"pwd": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										MaxItems:    1,
+										Description: "A block that specifies the password trigger configuration.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enabled": {
+													Type:        schema.TypeBool,
+													Optional:    true,
+													Description: "A boolean that specifies whether password trigger is enabled.",
+												},
+												"time": {
+													Type:        schema.TypeFloat,
+													Optional:    true,
+													Description: "A number that specifies the password trigger time.",
+												},
+												"time_format": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													Description:      "A string that specifies the password trigger time format. Valid values are `min`, `hour`, `day`.",
+													ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"min", "hour", "day"}, false)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"status": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -322,6 +399,63 @@ func expandAppPolicy(d *schema.ResourceData) (*dv.Policy, error) {
 		policy.PolicyFlows = policyFlows
 	}
 
+	if v, ok := d.GetOk("trigger"); ok {
+		triggerList := v.([]interface{})
+		if len(triggerList) > 0 && triggerList[0] != nil {
+			triggerMap := triggerList[0].(map[string]interface{})
+			policyTrigger := &dv.PolicyTrigger{}
+
+			// NOTE: policyTrigger.Type is intentionally NOT set here.
+			// The DaVinci API rejects "type" as an additional property on POST/PUT.
+			// The API sets the type itself and returns it on GET; flattenAppPolicy reads it from state.
+
+			if configList, ok := triggerMap["configuration"].([]interface{}); ok && len(configList) > 0 && configList[0] != nil {
+				configMap := configList[0].(map[string]interface{})
+				triggerConfig := &dv.TriggerConfiguration{}
+
+				if mfaList, ok := configMap["mfa"].([]interface{}); ok && len(mfaList) > 0 && mfaList[0] != nil {
+					mfaMap := mfaList[0].(map[string]interface{})
+					mfaConfig := &dv.TriggerConfigurationMFA{}
+
+					if enabled, ok := mfaMap["enabled"].(bool); ok {
+						mfaConfig.Enabled = &enabled
+					}
+					if timeVal, ok := mfaMap["time"].(float64); ok {
+						v := float32(timeVal)
+						mfaConfig.Time = &v
+					}
+					if timeFormat, ok := mfaMap["time_format"].(string); ok && timeFormat != "" {
+						mfaConfig.TimeFormat = &timeFormat
+					}
+
+					triggerConfig.MFA = mfaConfig
+				}
+
+				if pwdList, ok := configMap["pwd"].([]interface{}); ok && len(pwdList) > 0 && pwdList[0] != nil {
+					pwdMap := pwdList[0].(map[string]interface{})
+					pwdConfig := &dv.TriggerConfigurationPassword{}
+
+					if enabled, ok := pwdMap["enabled"].(bool); ok {
+						pwdConfig.Enabled = &enabled
+					}
+					if timeVal, ok := pwdMap["time"].(float64); ok {
+						v := float32(timeVal)
+						pwdConfig.Time = &v
+					}
+					if timeFormat, ok := pwdMap["time_format"].(string); ok && timeFormat != "" {
+						pwdConfig.TimeFormat = &timeFormat
+					}
+
+					triggerConfig.PWD = pwdConfig
+				}
+
+				policyTrigger.Configuration = triggerConfig
+			}
+
+			policy.Trigger = policyTrigger
+		}
+	}
+
 	return &policy, nil
 }
 
@@ -375,6 +509,56 @@ func flattenAppPolicy(app *dv.App, policyId string) (map[string]interface{}, err
 	}
 
 	a["policy_flow"] = polFlows
+
+	if policy.Trigger != nil {
+		triggerMap := map[string]interface{}{}
+
+		if policy.Trigger.Type != nil {
+			triggerMap["type"] = *policy.Trigger.Type
+		}
+
+		if policy.Trigger.Configuration != nil {
+			configMap := map[string]interface{}{}
+
+			if policy.Trigger.Configuration.MFA != nil {
+				mfaMap := map[string]interface{}{}
+				mfa := policy.Trigger.Configuration.MFA
+
+				if mfa.Enabled != nil {
+					mfaMap["enabled"] = *mfa.Enabled
+				}
+				if mfa.Time != nil {
+					mfaMap["time"] = float64(*mfa.Time)
+				}
+				if mfa.TimeFormat != nil {
+					mfaMap["time_format"] = *mfa.TimeFormat
+				}
+
+				configMap["mfa"] = []interface{}{mfaMap}
+			}
+
+			if policy.Trigger.Configuration.PWD != nil {
+				pwdMap := map[string]interface{}{}
+				pwd := policy.Trigger.Configuration.PWD
+
+				if pwd.Enabled != nil {
+					pwdMap["enabled"] = *pwd.Enabled
+				}
+				if pwd.Time != nil {
+					pwdMap["time"] = float64(*pwd.Time)
+				}
+				if pwd.TimeFormat != nil {
+					pwdMap["time_format"] = *pwd.TimeFormat
+				}
+
+				configMap["pwd"] = []interface{}{pwdMap}
+			}
+
+			triggerMap["configuration"] = []interface{}{configMap}
+		}
+
+		a["trigger"] = []interface{}{triggerMap}
+	}
 
 	//Return
 	return a, nil

--- a/internal/service/davinci/resource_application_flow_policy_test.go
+++ b/internal/service/davinci/resource_application_flow_policy_test.go
@@ -559,6 +559,328 @@ resource "davinci_application_flow_policy" "%[2]s" {
 `, acctest.PingoneEnvironmentSsoHcl(resourceName, withBootstrapConfig), resourceName, name, flowResources), nil
 }
 
+func TestAccResourceApplicationFlowPolicy_WithTrigger_Full(t *testing.T) {
+
+	withBootstrapConfig := false
+
+	resourceBase := "davinci_application_flow_policy"
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("%s.%s", resourceBase, resourceName)
+
+	name := resourceName
+
+	fullStepHcl, err := testAccResourceApplicationFlowPolicy_WithTrigger_Full_HCL(resourceName, name, withBootstrapConfig)
+	if err != nil {
+		t.Fatalf("Failed to generate HCL: %v", err)
+	}
+
+	fullStep := resource.TestStep{
+		Config: fullStepHcl,
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.#", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.type", "AUTHENTICATION"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.configuration.#", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.configuration.0.mfa.#", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.configuration.0.mfa.0.enabled", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.configuration.0.mfa.0.time", "30"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.configuration.0.mfa.0.time_format", "min"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.configuration.0.pwd.#", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.configuration.0.pwd.0.enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.configuration.0.pwd.0.time", "60"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.configuration.0.pwd.0.time_format", "min"),
+		),
+	}
+
+	minimalStepHcl, err := testAccResourceApplicationFlowPolicy_WithTrigger_Minimal_HCL(resourceName, name, withBootstrapConfig)
+	if err != nil {
+		t.Fatalf("Failed to generate HCL: %v", err)
+	}
+
+	minimalStep := resource.TestStep{
+		Config: minimalStepHcl,
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.#", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.type", "AUTHENTICATION"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.configuration.#", "0"),
+		),
+	}
+
+	noTriggerStepHcl, err := testAccResourceApplicationFlowPolicy_WithP1Flow_NoTrigger_HCL(resourceName, name, withBootstrapConfig)
+	if err != nil {
+		t.Fatalf("Failed to generate HCL: %v", err)
+	}
+
+	noTriggerStep := resource.TestStep{
+		Config: noTriggerStepHcl,
+		Check: resource.ComposeTestCheckFunc(
+			// Trigger is retained by the DaVinci API for PingOne flow policies even when omitted
+			// from HCL. With trigger as Optional+Computed, no plan diff occurs — this step
+			// validates no breaking state change when upgrading from HCL without a trigger block.
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.#", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "trigger.0.type", "AUTHENTICATION"),
+		),
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNewEnvironment(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		CheckDestroy:             davinci.ApplicationFlowPolicy_CheckDestroy(),
+		Steps: []resource.TestStep{
+			// Create from scratch with full trigger
+			fullStep,
+			{
+				Config:  fullStepHcl,
+				Destroy: true,
+			},
+			// Create from scratch with minimal trigger
+			minimalStep,
+			{
+				Config:  minimalStepHcl,
+				Destroy: true,
+			},
+			// Test updates
+			fullStep,
+			minimalStep,
+			fullStep,
+			// Apply config without trigger block - validates no breaking state change on upgrade
+			noTriggerStep,
+			// Test importing the resource
+			{
+				ResourceName: resourceFullName,
+				ImportStateIdFunc: func() resource.ImportStateIdFunc {
+					return func(s *terraform.State) (string, error) {
+						rs, ok := s.RootModule().Resources[resourceFullName]
+						if !ok {
+							return "", fmt.Errorf("Resource Not found: %s", resourceFullName)
+						}
+
+						return fmt.Sprintf("%s/%s/%s", rs.Primary.Attributes["environment_id"], rs.Primary.Attributes["application_id"], rs.Primary.ID), nil
+					}
+				}(),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"created_date", // https://github.com/pingidentity/terraform-provider-davinci/issues/257
+				},
+			},
+		},
+	})
+}
+
+func testAccResourceApplicationFlowPolicy_WithTrigger_Full_HCL(resourceName, name string, withBootstrapConfig bool) (hcl string, err error) {
+	p1FlowResources, err := p1FlowResources(resourceName, name)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "davinci_application" "%[2]s" {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[3]s"
+
+  oauth {
+    values {
+      allowed_grants = ["authorizationCode"]
+      allowed_scopes = ["openid", "profile"]
+      redirect_uris = [
+        "https://auth.ping-eng.com/env-id/rp/callback/openid_connect",
+      ]
+    }
+  }
+}
+
+resource "davinci_application_flow_policy" "%[2]s" {
+  environment_id = pingone_environment.%[2]s.id
+  application_id = davinci_application.%[2]s.id
+
+  name   = "%[3]s"
+  status = "enabled"
+
+  policy_flow {
+    flow_id    = davinci_flow.%[2]s-p1.id
+    version_id = -1
+    weight     = 100
+  }
+
+  trigger {
+    configuration {
+      mfa {
+        enabled     = true
+        time        = 30
+        time_format = "min"
+      }
+      pwd {
+        enabled     = false
+        time        = 60
+        time_format = "min"
+      }
+    }
+  }
+}
+
+%[4]s
+`, acctest.PingoneEnvironmentSsoHcl(resourceName, withBootstrapConfig), resourceName, name, p1FlowResources), nil
+}
+
+func testAccResourceApplicationFlowPolicy_WithTrigger_Minimal_HCL(resourceName, name string, withBootstrapConfig bool) (hcl string, err error) {
+	p1FlowResources, err := p1FlowResources(resourceName, name)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "davinci_application" "%[2]s" {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[3]s"
+
+  oauth {
+    values {
+      allowed_grants = ["authorizationCode"]
+      allowed_scopes = ["openid", "profile"]
+      redirect_uris = [
+        "https://auth.ping-eng.com/env-id/rp/callback/openid_connect",
+      ]
+    }
+  }
+}
+
+resource "davinci_application_flow_policy" "%[2]s" {
+  environment_id = pingone_environment.%[2]s.id
+  application_id = davinci_application.%[2]s.id
+
+  name   = "%[3]s"
+  status = "enabled"
+
+  policy_flow {
+    flow_id    = davinci_flow.%[2]s-p1.id
+    version_id = -1
+    weight     = 100
+  }
+
+  trigger {
+  }
+}
+
+%[4]s
+`, acctest.PingoneEnvironmentSsoHcl(resourceName, withBootstrapConfig), resourceName, name, p1FlowResources), nil
+}
+
+func testAccResourceApplicationFlowPolicy_WithP1Flow_NoTrigger_HCL(resourceName, name string, withBootstrapConfig bool) (hcl string, err error) {
+	p1FlowResources, err := p1FlowResources(resourceName, name)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "davinci_application" "%[2]s" {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[3]s"
+
+  oauth {
+    values {
+      allowed_grants = ["authorizationCode"]
+      allowed_scopes = ["openid", "profile"]
+      redirect_uris = [
+        "https://auth.ping-eng.com/env-id/rp/callback/openid_connect",
+      ]
+    }
+  }
+}
+
+resource "davinci_application_flow_policy" "%[2]s" {
+  environment_id = pingone_environment.%[2]s.id
+  application_id = davinci_application.%[2]s.id
+
+  name   = "%[3]s"
+  status = "enabled"
+
+  policy_flow {
+    flow_id    = davinci_flow.%[2]s-p1.id
+    version_id = -1
+    weight     = 100
+  }
+}
+
+%[4]s
+`, acctest.PingoneEnvironmentSsoHcl(resourceName, withBootstrapConfig), resourceName, name, p1FlowResources), nil
+}
+
+func p1FlowResources(resourceName, name string) (hcl string, err error) {
+	mainFlowJson, err := acctest.ReadFlowJsonFile("flows/p1sessionmainflow.json")
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(`
+resource "davinci_connection" "%[1]s-p1auth" {
+  environment_id = pingone_environment.%[1]s.id
+  connector_id   = "pingOneAuthenticationConnector"
+  name           = "%[2]s-p1auth"
+}
+
+resource "davinci_connection" "%[1]s-flow" {
+  environment_id = pingone_environment.%[1]s.id
+  connector_id   = "flowConnector"
+  name           = "%[2]s-flow"
+}
+
+resource "davinci_connection" "%[1]s-node" {
+  environment_id = pingone_environment.%[1]s.id
+  connector_id   = "nodeConnector"
+  name           = "%[2]s-node"
+}
+
+resource "davinci_connection" "%[1]s-annotation" {
+  environment_id = pingone_environment.%[1]s.id
+  connector_id   = "annotationConnector"
+  name           = "%[2]s-annotation"
+}
+
+resource "davinci_flow" "%[1]s-p1" {
+  environment_id = pingone_environment.%[1]s.id
+
+  flow_json = <<EOT
+%[3]s
+EOT
+
+  connection_link {
+    id                           = davinci_connection.%[1]s-p1auth.id
+    name                         = davinci_connection.%[1]s-p1auth.name
+    replace_import_connection_id = "054d0c6ac38a15f82497469675634cab"
+  }
+
+  connection_link {
+    id                           = davinci_connection.%[1]s-flow.id
+    name                         = davinci_connection.%[1]s-flow.name
+    replace_import_connection_id = "4f45de91338525b684c30eb2faccd568"
+  }
+
+  connection_link {
+    id                           = davinci_connection.%[1]s-node.id
+    name                         = davinci_connection.%[1]s-node.name
+    replace_import_connection_id = "3566e86a35c26e575396dcfb89a3dcc0"
+  }
+
+  connection_link {
+    id                           = davinci_connection.%[1]s-annotation.id
+    name                         = davinci_connection.%[1]s-annotation.name
+    replace_import_connection_id = "921bfae85c38ed45045e07be703d86b8"
+  }
+}
+`, resourceName, name, mainFlowJson), nil
+}
+
 func flowResources(resourceName, name string, count int) (hcl string, err error) {
 
 	mainFlowJson, err := acctest.ReadFlowJsonFile("flows/simple.json")


### PR DESCRIPTION
### Change Description
    Bump davinci-client-go to v0.13.0 and add trigger block to `davinci_application_flow_policy`

### Required SDK Upgrades
- github.com/samir-gandhi/davinci-client-go v0.13.0

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-davinci/internal/service/base -->
```shell
TF_ACC=1 go test -v -run TestAccResourceApplicationFlowPolicy_WithTrigger_Full ./internal/service/davinci/... -timeout 20m 2>&1
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell

```

</details>
